### PR TITLE
Test annotations for Natrix (Viper to GRASShopper)

### DIFF
--- a/src/test/resources/all/basic/abstract_funcs_and_preds.sil
+++ b/src/test/resources/all/basic/abstract_funcs_and_preds.sil
@@ -29,6 +29,7 @@ method test03(x: Ref, y: Ref) {
   x.f := y
 
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert fun02(x)
 }
 
@@ -45,6 +46,7 @@ method test04(x: Ref, y: Ref) {
   x.f := y
 
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert !fun03(x)
 }
 
@@ -63,5 +65,6 @@ method client(id: Int) {
   file_close(id)
 
   //:: ExpectedOutput(call.precondition:insufficient.permission)
+  //:: MissingOutput(call.precondition:insufficient.permission, /dummy/issue/0003/)
   file_close(id)
 }

--- a/src/test/resources/all/basic/abstract_funcs_and_preds.sil
+++ b/src/test/resources/all/basic/abstract_funcs_and_preds.sil
@@ -29,7 +29,7 @@ method test03(x: Ref, y: Ref) {
   x.f := y
 
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert fun02(x)
 }
 
@@ -46,7 +46,7 @@ method test04(x: Ref, y: Ref) {
   x.f := y
 
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert !fun03(x)
 }
 
@@ -65,6 +65,6 @@ method client(id: Int) {
   file_close(id)
 
   //:: ExpectedOutput(call.precondition:insufficient.permission)
-  //:: MissingOutput(call.precondition:insufficient.permission, /dummy/issue/0003/)
+  //:: MissingOutput(call.precondition:insufficient.permission, /natrix/issue/0003/)
   file_close(id)
 }

--- a/src/test/resources/all/basic/define.sil
+++ b/src/test/resources/all/basic/define.sil
@@ -47,7 +47,7 @@ method test05(x: Int) {
   assume fun01(sfx(i))
 
   while (i < 0)
-    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0020/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /natrix/issue/0020/)
     invariant fun01(sfx(i))
   {
     i := i + 1

--- a/src/test/resources/all/basic/define.sil
+++ b/src/test/resources/all/basic/define.sil
@@ -47,6 +47,7 @@ method test05(x: Int) {
   assume fun01(sfx(i))
 
   while (i < 0)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0020/)
     invariant fun01(sfx(i))
   {
     i := i + 1

--- a/src/test/resources/all/basic/fold.sil
+++ b/src/test/resources/all/basic/fold.sil
@@ -20,7 +20,7 @@ method t2(r: Ref) returns ()
 {
     r.f := 1
     //:: ExpectedOutput(fold.failed:assertion.false)
-    //:: MissingOutput(fold.failed:assertion.false, /dummy/issue/0019/)
+    //:: MissingOutput(fold.failed:assertion.false, /natrix/issue/0019/)
     fold acc(valid(r), write)
 }
 
@@ -29,6 +29,6 @@ method t3(r: Ref) returns ()
 {
     r.f := 1
     //:: ExpectedOutput(unfold.failed:insufficient.permission)
-    //:: MissingOutput(unfold.failed:insufficient.permission, /dummy/issue/0019/)
+    //:: MissingOutput(unfold.failed:insufficient.permission, /natrix/issue/0019/)
     unfold acc(valid(r), write)
 }

--- a/src/test/resources/all/basic/fold.sil
+++ b/src/test/resources/all/basic/fold.sil
@@ -20,6 +20,7 @@ method t2(r: Ref) returns ()
 {
     r.f := 1
     //:: ExpectedOutput(fold.failed:assertion.false)
+    //:: MissingOutput(fold.failed:assertion.false, /dummy/issue/0019/)
     fold acc(valid(r), write)
 }
 
@@ -28,5 +29,6 @@ method t3(r: Ref) returns ()
 {
     r.f := 1
     //:: ExpectedOutput(unfold.failed:insufficient.permission)
+    //:: MissingOutput(unfold.failed:insufficient.permission, /dummy/issue/0019/)
     unfold acc(valid(r), write)
 }

--- a/src/test/resources/all/basic/unfolding.sil
+++ b/src/test/resources/all/basic/unfolding.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/0000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 field f: Int
 field next: Ref
 

--- a/src/test/resources/all/basic/unfolding.sil
+++ b/src/test/resources/all/basic/unfolding.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/0000/)
 field f: Int
 field next: Ref
 

--- a/src/test/resources/all/chalice/cyclic-list.sil
+++ b/src/test/resources/all/chalice/cyclic-list.sil
@@ -26,6 +26,7 @@ method test1(this: Ref)
   x.next := x
 
   //:: ExpectedOutput(fold.failed:insufficient.permission)
+  //:: MissingOutput(fold.failed:insufficient.permission, /dummy/issue/0019/)
   fold acc(valid(x), write)
 }
 
@@ -38,5 +39,6 @@ method test2(this: Ref)
 
   //:: ExpectedOutput(application.precondition:insufficient.permission)
   //:: IgnoreOthers
+  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0019/)
   assert ((length(x)) == (length(x.next) + 1))
 }

--- a/src/test/resources/all/chalice/cyclic-list.sil
+++ b/src/test/resources/all/chalice/cyclic-list.sil
@@ -26,7 +26,7 @@ method test1(this: Ref)
   x.next := x
 
   //:: ExpectedOutput(fold.failed:insufficient.permission)
-  //:: MissingOutput(fold.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(fold.failed:insufficient.permission, /natrix/issue/0019/)
   fold acc(valid(x), write)
 }
 
@@ -39,6 +39,6 @@ method test2(this: Ref)
 
   //:: ExpectedOutput(application.precondition:insufficient.permission)
   //:: IgnoreOthers
-  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0019/)
   assert ((length(x)) == (length(x.next) + 1))
 }

--- a/src/test/resources/all/chalice/framing-fields.sil
+++ b/src/test/resources/all/chalice/framing-fields.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
   field value: Int
   field next: Ref

--- a/src/test/resources/all/chalice/framing-fields.sil
+++ b/src/test/resources/all/chalice/framing-fields.sil
@@ -1,3 +1,5 @@
+//:: IgnoreFile(/dummy/issue/000/)
+
   field value: Int
   field next: Ref
   predicate valid(this: Ref) { acc(this.value, write) && acc(this.next, write) && (((this.next) != (null)) ==> acc(valid(this.next), write)) }

--- a/src/test/resources/all/chalice/framing-functions.sil
+++ b/src/test/resources/all/chalice/framing-functions.sil
@@ -1,3 +1,5 @@
+//:: IgnoreFile(/dummy/issue/0000/)
+
   field value: Int
   field next: Ref
   predicate valid(this: Ref) { acc(this.value, write) && acc(this.next, write) && (((this.next) != (null)) ==> acc(valid(this.next), write)) }

--- a/src/test/resources/all/chalice/framing-functions.sil
+++ b/src/test/resources/all/chalice/framing-functions.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/0000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
   field value: Int
   field next: Ref

--- a/src/test/resources/all/chalice/internal-bug-2.sil
+++ b/src/test/resources/all/chalice/internal-bug-2.sil
@@ -6,9 +6,9 @@ method koko(this: Ref)
   requires acc(inv(this), write)
 {
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
-  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
   this.x := this.x + 1
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0019/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0019/)
   assert (((unfolding acc(inv(this), write) in this.x)) == (old((unfolding acc(inv(this), write) in this.x))))
 }

--- a/src/test/resources/all/chalice/internal-bug-2.sil
+++ b/src/test/resources/all/chalice/internal-bug-2.sil
@@ -6,7 +6,9 @@ method koko(this: Ref)
   requires acc(inv(this), write)
 {
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
   this.x := this.x + 1
 
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0019/)
   assert (((unfolding acc(inv(this), write) in this.x)) == (old((unfolding acc(inv(this), write) in this.x))))
 }

--- a/src/test/resources/all/chalice/test1.sil
+++ b/src/test/resources/all/chalice/test1.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
   field value: Int
   field next: Ref

--- a/src/test/resources/all/chalice/test1.sil
+++ b/src/test/resources/all/chalice/test1.sil
@@ -1,3 +1,5 @@
+//:: IgnoreFile(/dummy/issue/000/)
+
   field value: Int
   field next: Ref
   predicate inv(this: Ref) { acc(this.value, write) && acc(this.next, write) && (((this.next) != (null)) ==> acc(inv(this.next), write)) }

--- a/src/test/resources/all/chalice/test10.sil
+++ b/src/test/resources/all/chalice/test10.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
   field value: Int
   field next: Ref

--- a/src/test/resources/all/chalice/test10.sil
+++ b/src/test/resources/all/chalice/test10.sil
@@ -1,3 +1,5 @@
+//:: IgnoreFile(/dummy/issue/000/)
+
   field value: Int
   field next: Ref
   predicate inv(this: Ref) { acc(this.value, write) && acc(this.next, write) && (((this.next) != (null)) ==> acc(inv(this.next), write)) }

--- a/src/test/resources/all/chalice/test7.sil
+++ b/src/test/resources/all/chalice/test7.sil
@@ -61,7 +61,7 @@
     assert acc(this.value, write)
     fold acc(inv(this), write)
     //:: ExpectedOutput(assert.failed:insufficient.permission)
-    //:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0019/)
+    //:: MissingOutput(assert.failed:insufficient.permission, /natrix/issue/0019/)
     assert acc(this.value, write)
   }
   method uf1(this: Ref)
@@ -84,34 +84,34 @@
     assert acc(inv(this), write)
     unfold acc(inv(this), write)
     //:: ExpectedOutput(assert.failed:insufficient.permission)
-    //:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0019/)
+    //:: MissingOutput(assert.failed:insufficient.permission, /natrix/issue/0019/)
     assert acc(inv(this), write)
   }
   method badframing0(this: Ref)
     requires this != null
     //:: ExpectedOutput(application.precondition:insufficient.permission)
-    //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
+    //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0003/)
     requires ((get(this)) == (2))
   {
   }
   method badframing1(this: Ref)
     requires this != null
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
-    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
     requires ((this.value) == (2))
   {
   }
   method badframing2(this: Ref)
     requires this != null
     //:: ExpectedOutput(application.precondition:insufficient.permission)
-    //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
+    //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0003/)
     requires acc(this.value, write) && ((get(this)) == (2))
   {
   }
   method badframing3(this: Ref)
     requires this != null
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
-    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
     requires acc(inv(this), write) && ((this.value) == (2))
   {
   }

--- a/src/test/resources/all/chalice/test7.sil
+++ b/src/test/resources/all/chalice/test7.sil
@@ -61,6 +61,7 @@
     assert acc(this.value, write)
     fold acc(inv(this), write)
     //:: ExpectedOutput(assert.failed:insufficient.permission)
+    //:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0019/)
     assert acc(this.value, write)
   }
   method uf1(this: Ref)
@@ -83,29 +84,34 @@
     assert acc(inv(this), write)
     unfold acc(inv(this), write)
     //:: ExpectedOutput(assert.failed:insufficient.permission)
+    //:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0019/)
     assert acc(inv(this), write)
   }
   method badframing0(this: Ref)
     requires this != null
     //:: ExpectedOutput(application.precondition:insufficient.permission)
+    //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
     requires ((get(this)) == (2))
   {
   }
   method badframing1(this: Ref)
     requires this != null
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
     requires ((this.value) == (2))
   {
   }
   method badframing2(this: Ref)
     requires this != null
     //:: ExpectedOutput(application.precondition:insufficient.permission)
+    //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
     requires acc(this.value, write) && ((get(this)) == (2))
   {
   }
   method badframing3(this: Ref)
     requires this != null
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
     requires acc(inv(this), write) && ((this.value) == (2))
   {
   }

--- a/src/test/resources/all/chalice/test8.sil
+++ b/src/test/resources/all/chalice/test8.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
   field value: Int
   field next: Ref

--- a/src/test/resources/all/chalice/test8.sil
+++ b/src/test/resources/all/chalice/test8.sil
@@ -1,3 +1,5 @@
+//:: IgnoreFile(/dummy/issue/000/)
+
   field value: Int
   field next: Ref
   predicate inv(this: Ref) { acc(this.value, write) }

--- a/src/test/resources/all/functions/basic2.sil
+++ b/src/test/resources/all/functions/basic2.sil
@@ -1,5 +1,6 @@
 function fun01(): Int
   //:: ExpectedOutput(not.wellformed:division.by.zero)
+  //:: MissingOutput(not.wellformed:division.by.zero, /dummy/issue/0008/)
   ensures 1 \ result != 1
 
 function fun02(): Int

--- a/src/test/resources/all/functions/basic2.sil
+++ b/src/test/resources/all/functions/basic2.sil
@@ -1,6 +1,6 @@
 function fun01(): Int
   //:: ExpectedOutput(not.wellformed:division.by.zero)
-  //:: MissingOutput(not.wellformed:division.by.zero, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:division.by.zero, /natrix/issue/0008/)
   ensures 1 \ result != 1
 
 function fun02(): Int

--- a/src/test/resources/all/functions/framing_abstract_functions.sil
+++ b/src/test/resources/all/functions/framing_abstract_functions.sil
@@ -14,6 +14,6 @@ method test01(x: Ref, b: Bool)
   assert fun01(x, true) == 1
 
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert fun01(x, false) == -1
 }

--- a/src/test/resources/all/functions/framing_abstract_functions.sil
+++ b/src/test/resources/all/functions/framing_abstract_functions.sil
@@ -14,5 +14,6 @@ method test01(x: Ref, b: Bool)
   assert fun01(x, true) == 1
 
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert fun01(x, false) == -1
 }

--- a/src/test/resources/all/functions/functions.sil
+++ b/src/test/resources/all/functions/functions.sil
@@ -40,19 +40,19 @@ function fun5(x: Ref): Int
 
 function err1(x: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires acc(x.h.f)
 { 0 }
 
 function err2(x: Ref): Int
   requires acc(x.f)
   //:: ExpectedOutput(application.precondition:insufficient.permission)
-  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
+  //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0003/)
   requires err1(x) == 0
 { 0 }
 
 //:: ExpectedOutput(function.not.wellformed:insufficient.permission)
-//:: MissingOutput(function.not.wellformed:insufficient.permission, /dummy/issue/0008/)
+//:: MissingOutput(function.not.wellformed:insufficient.permission, /natrix/issue/0008/)
 function er3(x: Ref, y: Ref): Int
   requires acc(x.f) && acc(y.g)
 { y.f + x.g }

--- a/src/test/resources/all/functions/functions.sil
+++ b/src/test/resources/all/functions/functions.sil
@@ -40,16 +40,19 @@ function fun5(x: Ref): Int
 
 function err1(x: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires acc(x.h.f)
 { 0 }
 
 function err2(x: Ref): Int
   requires acc(x.f)
   //:: ExpectedOutput(application.precondition:insufficient.permission)
+  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
   requires err1(x) == 0
 { 0 }
 
 //:: ExpectedOutput(function.not.wellformed:insufficient.permission)
+//:: MissingOutput(function.not.wellformed:insufficient.permission, /dummy/issue/0008/)
 function er3(x: Ref, y: Ref): Int
   requires acc(x.f) && acc(y.g)
 { y.f + x.g }

--- a/src/test/resources/all/functions/heap_dependent_triggers.sil
+++ b/src/test/resources/all/functions/heap_dependent_triggers.sil
@@ -16,7 +16,7 @@ method test01a(x: Ref) {
   inhale fun01(x, 5)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/204/)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0018/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0018/)
   assert bar01(5) > 0
 }
 
@@ -76,6 +76,6 @@ method test03c(x: Ref, y: Ref)
   inhale fun01(x, 5)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/204/)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0018/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0018/)
   assert bar01(5) > 0
 }

--- a/src/test/resources/all/functions/heap_dependent_triggers.sil
+++ b/src/test/resources/all/functions/heap_dependent_triggers.sil
@@ -16,6 +16,7 @@ method test01a(x: Ref) {
   inhale fun01(x, 5)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/204/)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0018/)
   assert bar01(5) > 0
 }
 
@@ -75,5 +76,6 @@ method test03c(x: Ref, y: Ref)
   inhale fun01(x, 5)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/204/)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0018/)
   assert bar01(5) > 0
 }

--- a/src/test/resources/all/functions/nested.sil
+++ b/src/test/resources/all/functions/nested.sil
@@ -48,7 +48,7 @@ method test03() {
   x.g.f := 17
 
   assert fun4(true, x, x) == 7 - 3 + 17 + 17
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0020/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0020/)
   assert fun4(false, x, x) == 7 + 3 + 99
 
   //:: ExpectedOutput(assert.failed:assertion.false)
@@ -58,7 +58,7 @@ method test03() {
 function fun5(x: Ref): Int
   requires acc(x.f)
   //:: ExpectedOutput(application.precondition:insufficient.permission)
-  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
+  //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0003/)
 { fun3(x) }
 
 function fun6(x: Ref): Int

--- a/src/test/resources/all/functions/nested.sil
+++ b/src/test/resources/all/functions/nested.sil
@@ -48,6 +48,7 @@ method test03() {
   x.g.f := 17
 
   assert fun4(true, x, x) == 7 - 3 + 17 + 17
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0020/)
   assert fun4(false, x, x) == 7 + 3 + 99
 
   //:: ExpectedOutput(assert.failed:assertion.false)
@@ -57,6 +58,7 @@ method test03() {
 function fun5(x: Ref): Int
   requires acc(x.f)
   //:: ExpectedOutput(application.precondition:insufficient.permission)
+  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
 { fun3(x) }
 
 function fun6(x: Ref): Int

--- a/src/test/resources/all/functions/recursion.sil
+++ b/src/test/resources/all/functions/recursion.sil
@@ -7,7 +7,7 @@ function fac(n: Int): Int
 
 method test() {
   assert fac(0) == 0
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert fac(1) == 1
   assert fac(2) == 2
   assert fac(3) == 6
@@ -21,6 +21,6 @@ method test() {
 function err1(n: Int): Int
   requires n >= 0
   //:: ExpectedOutput(postcondition.violated:assertion.false)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0003/)
   ensures result >= 0
 { n <= 1 ? 1 : err1(n - 1) - n }

--- a/src/test/resources/all/functions/recursion.sil
+++ b/src/test/resources/all/functions/recursion.sil
@@ -7,6 +7,7 @@ function fac(n: Int): Int
 
 method test() {
   assert fac(0) == 0
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert fac(1) == 1
   assert fac(2) == 2
   assert fac(3) == 6
@@ -20,5 +21,6 @@ method test() {
 function err1(n: Int): Int
   requires n >= 0
   //:: ExpectedOutput(postcondition.violated:assertion.false)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
   ensures result >= 0
 { n <= 1 ? 1 : err1(n - 1) - n }

--- a/src/test/resources/all/functions/recursive_unrolling.sil
+++ b/src/test/resources/all/functions/recursive_unrolling.sil
@@ -33,7 +33,7 @@ method test01() {
   n5.next := n4
   fold acc(node(n5))
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0021/)
   assert length(n5) == 5
 }
 
@@ -45,6 +45,6 @@ method test02(n4: Ref)
   unfold acc(node(n4.next.next))
   unfold acc(node(n4.next.next.next))
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0021/)
   assert n4.next.next.next.next == null
 }

--- a/src/test/resources/all/functions/recursive_unrolling.sil
+++ b/src/test/resources/all/functions/recursive_unrolling.sil
@@ -33,6 +33,7 @@ method test01() {
   n5.next := n4
   fold acc(node(n5))
 
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
   assert length(n5) == 5
 }
 
@@ -44,5 +45,6 @@ method test02(n4: Ref)
   unfold acc(node(n4.next.next))
   unfold acc(node(n4.next.next.next))
 
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
   assert n4.next.next.next.next == null
 }

--- a/src/test/resources/all/functions/unfolding_nonnull.sil
+++ b/src/test/resources/all/functions/unfolding_nonnull.sil
@@ -13,6 +13,7 @@ method test6(x: Ref)
 {
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
   assert x != null
 }
 
@@ -29,9 +30,11 @@ method test7(x: Ref, y: Ref)
 {
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
   assert x != null
   
   // :: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
   assert y != null
 }

--- a/src/test/resources/all/functions/unfolding_nonnull.sil
+++ b/src/test/resources/all/functions/unfolding_nonnull.sil
@@ -13,7 +13,7 @@ method test6(x: Ref)
 {
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0023/)
   assert x != null
 }
 
@@ -30,11 +30,11 @@ method test7(x: Ref, y: Ref)
 {
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0023/)
   assert x != null
   
   // :: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/112/)
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/026/)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0023/)
   assert y != null
 }

--- a/src/test/resources/all/inhale_exhale/loops.sil
+++ b/src/test/resources/all/inhale_exhale/loops.sil
@@ -28,7 +28,7 @@ method loopTrueFalse(this: Ref)
   i := 1
   while (i < 10)
     //:: ExpectedOutput(invariant.not.established:assertion.false)
-    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /dummy/issue/0002/)
+    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /natrix/issue/0002/)
     invariant [true, false]
   {
     i := i + 1

--- a/src/test/resources/all/inhale_exhale/loops.sil
+++ b/src/test/resources/all/inhale_exhale/loops.sil
@@ -28,6 +28,7 @@ method loopTrueFalse(this: Ref)
   i := 1
   while (i < 10)
     //:: ExpectedOutput(invariant.not.established:assertion.false)
+    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /dummy/issue/0002/)
     invariant [true, false]
   {
     i := i + 1

--- a/src/test/resources/all/inhale_exhale/wellformedness.sil
+++ b/src/test/resources/all/inhale_exhale/wellformedness.sil
@@ -14,12 +14,14 @@ expressions are not used.
 
 method s0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this.x == 0
 {
 }
 
 method s1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures this.x == 0
 {
   inhale acc(this.x) && this.x == 0
@@ -27,12 +29,15 @@ method s1(this: Ref)
 
 method s2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null && this.x == 0
 {
 }
 
 method s3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures this != null && this.x == 0
 {
   inhale acc(this.x) && this.x == 0
@@ -48,12 +53,14 @@ Inhale.
 
 method i0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [this.x == 0, true]
 {
 }
 
 method i1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0
@@ -61,12 +68,14 @@ method i1(this: Ref)
 
 method i2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [this != null && this.x == 0, true]
 {
 }
 
 method i3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [this != null && this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0
@@ -79,6 +88,7 @@ Exhale.
 method e0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [true, this.x == 0]
 {
 }
@@ -86,6 +96,7 @@ method e0(this: Ref)
 method e1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [true, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -94,6 +105,7 @@ method e1(this: Ref)
 method e2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -101,6 +113,8 @@ method e2(this: Ref)
 method e3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -112,12 +126,14 @@ Both.
 
 method ie0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [this.x == 0, this.x == 0]
 {
 }
 
 method ie1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [this.x == 0, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -125,12 +141,15 @@ method ie1(this: Ref)
 
 method ie2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [this != null && this.x == 0, this != null && this.x == 0]
 {
 }
 
 method ie3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures [this != null && this.x == 0, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -150,6 +169,7 @@ method t1(this: Ref)
   requires [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -163,6 +183,7 @@ method t1(this: Ref)
 method t2(this: Ref)
   requires [true, acc(this.x)]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [this != null && this.x == 0, true]
 {
 }
@@ -177,6 +198,8 @@ method t3(this: Ref)
   ensures [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -191,6 +214,7 @@ method t3(this: Ref)
 method t4(this: Ref)
   ensures [true, acc(this.x)]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [this != null && this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/inhale_exhale/wellformedness.sil
+++ b/src/test/resources/all/inhale_exhale/wellformedness.sil
@@ -14,14 +14,14 @@ expressions are not used.
 
 method s0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this.x == 0
 {
 }
 
 method s1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures this.x == 0
 {
   inhale acc(this.x) && this.x == 0
@@ -29,15 +29,15 @@ method s1(this: Ref)
 
 method s2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null && this.x == 0
 {
 }
 
 method s3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures this != null && this.x == 0
 {
   inhale acc(this.x) && this.x == 0
@@ -53,14 +53,14 @@ Inhale.
 
 method i0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [this.x == 0, true]
 {
 }
 
 method i1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0
@@ -68,14 +68,14 @@ method i1(this: Ref)
 
 method i2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [this != null && this.x == 0, true]
 {
 }
 
 method i3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [this != null && this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0
@@ -88,7 +88,7 @@ Exhale.
 method e0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [true, this.x == 0]
 {
 }
@@ -96,7 +96,7 @@ method e0(this: Ref)
 method e1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [true, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -105,7 +105,7 @@ method e1(this: Ref)
 method e2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -113,8 +113,8 @@ method e2(this: Ref)
 method e3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -126,14 +126,14 @@ Both.
 
 method ie0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [this.x == 0, this.x == 0]
 {
 }
 
 method ie1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [this.x == 0, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -141,15 +141,15 @@ method ie1(this: Ref)
 
 method ie2(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [this != null && this.x == 0, this != null && this.x == 0]
 {
 }
 
 method ie3(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures [this != null && this.x == 0, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -169,7 +169,7 @@ method t1(this: Ref)
   requires [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -183,7 +183,7 @@ method t1(this: Ref)
 method t2(this: Ref)
   requires [true, acc(this.x)]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [this != null && this.x == 0, true]
 {
 }
@@ -198,8 +198,8 @@ method t3(this: Ref)
   ensures [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0
@@ -214,7 +214,7 @@ method t3(this: Ref)
 method t4(this: Ref)
   ensures [true, acc(this.x)]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [this != null && this.x == 0, true]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/issues/carbon/0012.sil
+++ b/src/test/resources/all/issues/carbon/0012.sil
@@ -11,13 +11,13 @@ method allocTest(x: Ref) {
   }
   
   y := new()
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   assert x != y
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   assert z != y
   
   inhale acc(x.f)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   assert y != x.f
   inhale acc(y.f)
   //:: ExpectedOutput(assert.failed:assertion.false)
@@ -34,21 +34,21 @@ method allocTest(x: Ref) {
   z := m()
   y := new()
   
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   assert x != y
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   assert z != y
   
   inhale acc(x.f)
-  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /natrix/issue/0004/)
   assert y != x.f
   inhale acc(y.f)
-  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /natrix/issue/0004/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   //:: ExpectedOutput(assert.failed:assertion.false)
   assert x != y.f
-  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0004/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /natrix/issue/0004/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0004/)
   //:: ExpectedOutput(assert.failed:assertion.false)
   assert x != x.f  
 }

--- a/src/test/resources/all/issues/carbon/0012.sil
+++ b/src/test/resources/all/issues/carbon/0012.sil
@@ -11,10 +11,13 @@ method allocTest(x: Ref) {
   }
   
   y := new()
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   assert x != y
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   assert z != y
   
   inhale acc(x.f)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   assert y != x.f
   inhale acc(y.f)
   //:: ExpectedOutput(assert.failed:assertion.false)
@@ -31,14 +34,21 @@ method allocTest(x: Ref) {
   z := m()
   y := new()
   
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   assert x != y
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   assert z != y
   
   inhale acc(x.f)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
   assert y != x.f
   inhale acc(y.f)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   //:: ExpectedOutput(assert.failed:assertion.false)
   assert x != y.f
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0004/)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0004/)
   //:: ExpectedOutput(assert.failed:assertion.false)
   assert x != x.f  
 }

--- a/src/test/resources/all/issues/carbon/0030.sil
+++ b/src/test/resources/all/issues/carbon/0030.sil
@@ -2,6 +2,7 @@ field x: Int
 
 //:: ExpectedOutput(predicate.not.wellformed:insufficient.permission)
 //:: MissingOutput(predicate.not.wellformed:insufficient.permission, /Carbon/issue/30/)
+//:: MissingOutput(predicate.not.wellformed:insufficient.permission, /dummy/issue/0008/)
 predicate P(this: Ref) {
   this != null && this.x == 1
 }

--- a/src/test/resources/all/issues/carbon/0030.sil
+++ b/src/test/resources/all/issues/carbon/0030.sil
@@ -2,7 +2,7 @@ field x: Int
 
 //:: ExpectedOutput(predicate.not.wellformed:insufficient.permission)
 //:: MissingOutput(predicate.not.wellformed:insufficient.permission, /Carbon/issue/30/)
-//:: MissingOutput(predicate.not.wellformed:insufficient.permission, /dummy/issue/0008/)
+//:: MissingOutput(predicate.not.wellformed:insufficient.permission, /natrix/issue/0008/)
 predicate P(this: Ref) {
   this != null && this.x == 1
 }

--- a/src/test/resources/all/issues/carbon/0052.sil
+++ b/src/test/resources/all/issues/carbon/0052.sil
@@ -3,7 +3,7 @@ field x: Int
 method f(this: Ref)
   requires acc(this.x)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures this.x == 1
 {
   this.x := 1

--- a/src/test/resources/all/issues/carbon/0052.sil
+++ b/src/test/resources/all/issues/carbon/0052.sil
@@ -3,6 +3,7 @@ field x: Int
 method f(this: Ref)
   requires acc(this.x)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures this.x == 1
 {
   this.x := 1

--- a/src/test/resources/all/issues/carbon/0059-3.sil
+++ b/src/test/resources/all/issues/carbon/0059-3.sil
@@ -7,6 +7,7 @@ predicate P(this: Ref) {
 method Testsuccess5(this: Ref)
   requires acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures unfolding P(this) in this.x >= this.x
 {
 }

--- a/src/test/resources/all/issues/carbon/0059-3.sil
+++ b/src/test/resources/all/issues/carbon/0059-3.sil
@@ -7,7 +7,7 @@ predicate P(this: Ref) {
 method Testsuccess5(this: Ref)
   requires acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures unfolding P(this) in this.x >= this.x
 {
 }

--- a/src/test/resources/all/issues/carbon/0063-1.sil
+++ b/src/test/resources/all/issues/carbon/0063-1.sil
@@ -27,7 +27,7 @@ field x: Int
 method test0(this: Ref)
   requires acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/34/)
   ensures (unfolding acc(P(this), write) in true) && this.x == 0
@@ -38,8 +38,8 @@ method test1(this: Ref)
 {
   inhale acc(P(this), write) && this != null
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
-  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
-  //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0002/)
+  //:: UnexpectedOutput(exhale.failed:assertion.false, /natrix/issue/0002/)
   exhale (unfolding acc(P(this), write) in true) && this.x == 0
 }
 
@@ -47,8 +47,8 @@ method test1Reference(this: Ref)
 {
   inhale this != null
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
-  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
-  //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0002/)
+  //:: UnexpectedOutput(exhale.failed:assertion.false, /natrix/issue/0002/)
   exhale true && this.x == 0
 }
 

--- a/src/test/resources/all/issues/carbon/0063-1.sil
+++ b/src/test/resources/all/issues/carbon/0063-1.sil
@@ -27,6 +27,7 @@ field x: Int
 method test0(this: Ref)
   requires acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/34/)
   ensures (unfolding acc(P(this), write) in true) && this.x == 0
@@ -37,6 +38,8 @@ method test1(this: Ref)
 {
   inhale acc(P(this), write) && this != null
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
+  //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
   exhale (unfolding acc(P(this), write) in true) && this.x == 0
 }
 
@@ -44,6 +47,8 @@ method test1Reference(this: Ref)
 {
   inhale this != null
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
+  //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
   exhale true && this.x == 0
 }
 

--- a/src/test/resources/all/issues/carbon/0066.sil
+++ b/src/test/resources/all/issues/carbon/0066.sil
@@ -69,6 +69,7 @@ method test15(this: Ref)
 method e0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/235/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [true, this.x == 0]
 {
 }
@@ -76,6 +77,7 @@ method e0(this: Ref)
 method e1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/235/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures [true, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/issues/carbon/0066.sil
+++ b/src/test/resources/all/issues/carbon/0066.sil
@@ -69,7 +69,7 @@ method test15(this: Ref)
 method e0(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/235/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [true, this.x == 0]
 {
 }
@@ -77,7 +77,7 @@ method e0(this: Ref)
 method e1(this: Ref)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/235/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures [true, this.x == 0]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/issues/carbon/0067.sil
+++ b/src/test/resources/all/issues/carbon/0067.sil
@@ -10,6 +10,7 @@ method t1(this: Ref)
   requires [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -24,6 +25,8 @@ method t3(this: Ref)
   ensures [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/issues/carbon/0067.sil
+++ b/src/test/resources/all/issues/carbon/0067.sil
@@ -10,7 +10,7 @@ method t1(this: Ref)
   requires [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires [true, this != null && this.x == 0]
 {
 }
@@ -25,8 +25,8 @@ method t3(this: Ref)
   ensures [acc(this.x), true]
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
   //:: MissingOutput(not.wellformed:insufficient.permission, /Silicon/issue/160/)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures [true, this != null && this.x == 0]
 {
   inhale acc(this.x) && this.x == 0

--- a/src/test/resources/all/issues/carbon/0069.sil
+++ b/src/test/resources/all/issues/carbon/0069.sil
@@ -3,11 +3,11 @@ field x: Int
 function postFunction(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0003/)
   ensures this.x == 0
 {
   1
@@ -16,10 +16,10 @@ function postFunction(this: Ref): Int
 method postMethod(this: Ref)
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0008/)
   ensures this.x == 0
 {
 }
@@ -27,7 +27,7 @@ method postMethod(this: Ref)
 function postFunction2(this: Ref): Int
   requires this != null && acc(this.x)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0003/)
   ensures this.x == 0
 {
   1

--- a/src/test/resources/all/issues/carbon/0069.sil
+++ b/src/test/resources/all/issues/carbon/0069.sil
@@ -3,9 +3,11 @@ field x: Int
 function postFunction(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
   ensures this.x == 0
 {
   1
@@ -14,8 +16,10 @@ function postFunction(this: Ref): Int
 method postMethod(this: Ref)
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0008/)
   ensures this.x == 0
 {
 }
@@ -23,6 +27,7 @@ method postMethod(this: Ref)
 function postFunction2(this: Ref): Int
   requires this != null && acc(this.x)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
   ensures this.x == 0
 {
   1

--- a/src/test/resources/all/issues/carbon/0070.sil
+++ b/src/test/resources/all/issues/carbon/0070.sil
@@ -8,12 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
-    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /natrix/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
-    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /natrix/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false

--- a/src/test/resources/all/issues/carbon/0070.sil
+++ b/src/test/resources/all/issues/carbon/0070.sil
@@ -8,9 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false

--- a/src/test/resources/all/issues/carbon/0122.sil
+++ b/src/test/resources/all/issues/carbon/0122.sil
@@ -18,6 +18,6 @@ method test(x: Ref) {
   v2 := fun(x)
     
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/122/)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert v1 == v2 // Fails in Carbon, verifies in Silicon
 }

--- a/src/test/resources/all/issues/carbon/0122.sil
+++ b/src/test/resources/all/issues/carbon/0122.sil
@@ -18,5 +18,6 @@ method test(x: Ref) {
   v2 := fun(x)
     
   //:: UnexpectedOutput(assert.failed:assertion.false, /carbon/issue/122/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert v1 == v2 // Fails in Carbon, verifies in Silicon
 }

--- a/src/test/resources/all/issues/silicon/0006.sil
+++ b/src/test/resources/all/issues/silicon/0006.sil
@@ -3,6 +3,7 @@ field f: Int
 method foo(x: Ref)
   requires x != null
   //:: ExpectedOutput(application.precondition:insufficient.permission)
+  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
   ensures bar(x)
 {}
 

--- a/src/test/resources/all/issues/silicon/0006.sil
+++ b/src/test/resources/all/issues/silicon/0006.sil
@@ -3,7 +3,7 @@ field f: Int
 method foo(x: Ref)
   requires x != null
   //:: ExpectedOutput(application.precondition:insufficient.permission)
-  //:: MissingOutput(application.precondition:insufficient.permission, /dummy/issue/0003/)
+  //:: MissingOutput(application.precondition:insufficient.permission, /natrix/issue/0003/)
   ensures bar(x)
 {}
 

--- a/src/test/resources/all/issues/silicon/0033.sil
+++ b/src/test/resources/all/issues/silicon/0033.sil
@@ -32,7 +32,7 @@ method unfoldTwice(this: Ref)
   unfold acc(valid(this), write)
   unfold acc(valid(this.next), write)
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0021/)
   assert this.next.next == null
 }
 
@@ -45,7 +45,7 @@ method unfoldThrice(this: Ref)
   unfold acc(valid(this.next), write)
   unfold acc(valid(this.next.next), write)
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0021/)
   assert this.next.next.next == null
 }
 

--- a/src/test/resources/all/issues/silicon/0033.sil
+++ b/src/test/resources/all/issues/silicon/0033.sil
@@ -32,6 +32,7 @@ method unfoldTwice(this: Ref)
   unfold acc(valid(this), write)
   unfold acc(valid(this.next), write)
 
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
   assert this.next.next == null
 }
 
@@ -44,6 +45,7 @@ method unfoldThrice(this: Ref)
   unfold acc(valid(this.next), write)
   unfold acc(valid(this.next.next), write)
 
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0021/)
   assert this.next.next.next == null
 }
 

--- a/src/test/resources/all/issues/silicon/0039b.sil
+++ b/src/test/resources/all/issues/silicon/0039b.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 /* class List */
 
 field List_head: Ref

--- a/src/test/resources/all/issues/silicon/0039b.sil
+++ b/src/test/resources/all/issues/silicon/0039b.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/000/)
 /* class List */
 
 field List_head: Ref

--- a/src/test/resources/all/issues/silicon/0041.sil
+++ b/src/test/resources/all/issues/silicon/0041.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/000/)
 field next: Ref
 
 predicate SL(x: Ref) {

--- a/src/test/resources/all/issues/silicon/0041.sil
+++ b/src/test/resources/all/issues/silicon/0041.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 field next: Ref
 
 predicate SL(x: Ref) {

--- a/src/test/resources/all/issues/silicon/0046.sil
+++ b/src/test/resources/all/issues/silicon/0046.sil
@@ -4,7 +4,7 @@ method test01(this: Ref)
   requires acc(this.f, write) && this.f == 0
 {
   while (true) {
-    //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0006/)
+    //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0006/)
     assert old(this.f) == 0 /* Used to fail */
   }
 

--- a/src/test/resources/all/issues/silicon/0046.sil
+++ b/src/test/resources/all/issues/silicon/0046.sil
@@ -4,6 +4,7 @@ method test01(this: Ref)
   requires acc(this.f, write) && this.f == 0
 {
   while (true) {
+    //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0006/)
     assert old(this.f) == 0 /* Used to fail */
   }
 

--- a/src/test/resources/all/issues/silicon/0053.sil
+++ b/src/test/resources/all/issues/silicon/0053.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/000/)
 field next: Ref
 field val: Int
 

--- a/src/test/resources/all/issues/silicon/0053.sil
+++ b/src/test/resources/all/issues/silicon/0053.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 field next: Ref
 field val: Int
 

--- a/src/test/resources/all/issues/silicon/0057.sil
+++ b/src/test/resources/all/issues/silicon/0057.sil
@@ -11,7 +11,7 @@ method m(o:Ref)
     o.f := 5
   }
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0030/)
-  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0030/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0030/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /natrix/issue/0030/)
   assert (o.f == old(o.f))
 }

--- a/src/test/resources/all/issues/silicon/0057.sil
+++ b/src/test/resources/all/issues/silicon/0057.sil
@@ -11,5 +11,7 @@ method m(o:Ref)
     o.f := 5
   }
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0030/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0030/)
   assert (o.f == old(o.f))
 }

--- a/src/test/resources/all/issues/silicon/0117.sil
+++ b/src/test/resources/all/issues/silicon/0117.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/0021/)
+//:: IgnoreFile(/natrix/issue/0021/)
 predicate p(this: Ref) { acc(p(this), write) }
 
 function fun(this: Ref): Bool

--- a/src/test/resources/all/issues/silicon/0117.sil
+++ b/src/test/resources/all/issues/silicon/0117.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/0021/)
 predicate p(this: Ref) { acc(p(this), write) }
 
 function fun(this: Ref): Bool

--- a/src/test/resources/all/issues/silicon/0144.sil
+++ b/src/test/resources/all/issues/silicon/0144.sil
@@ -1,6 +1,7 @@
 method callee(x: Int) returns (r: Int)
   requires true
   //:: ExpectedOutput(not.wellformed:division.by.zero)
+  //:: MissingOutput(not.wellformed:division.by.zero, /dummy/issue/0008/)
   ensures r == 1\x
 {
   //:: ExpectedOutput(assignment.failed:division.by.zero)

--- a/src/test/resources/all/issues/silicon/0144.sil
+++ b/src/test/resources/all/issues/silicon/0144.sil
@@ -1,7 +1,7 @@
 method callee(x: Int) returns (r: Int)
   requires true
   //:: ExpectedOutput(not.wellformed:division.by.zero)
-  //:: MissingOutput(not.wellformed:division.by.zero, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:division.by.zero, /natrix/issue/0008/)
   ensures r == 1\x
 {
   //:: ExpectedOutput(assignment.failed:division.by.zero)

--- a/src/test/resources/all/issues/silicon/0152.sil
+++ b/src/test/resources/all/issues/silicon/0152.sil
@@ -4,7 +4,7 @@ method m(this: Ref, z: Int)
   requires this != null
   requires acc(this.x, write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures this.x == z
 {
   this.x := z

--- a/src/test/resources/all/issues/silicon/0152.sil
+++ b/src/test/resources/all/issues/silicon/0152.sil
@@ -4,6 +4,7 @@ method m(this: Ref, z: Int)
   requires this != null
   requires acc(this.x, write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures this.x == z
 {
   this.x := z

--- a/src/test/resources/all/issues/silicon/0161.sil
+++ b/src/test/resources/all/issues/silicon/0161.sil
@@ -2,14 +2,14 @@ field x: Int
 
 function pre(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null && this.x == 0
 {
   1
 }
 
 //:: ExpectedOutput(function.not.wellformed:insufficient.permission)
-//:: MissingOutput(function.not.wellformed:insufficient.permission, /dummy/issue/0008/)
+//:: MissingOutput(function.not.wellformed:insufficient.permission, /natrix/issue/0008/)
 function body(this: Ref): Int
   requires this != null
 {
@@ -22,7 +22,7 @@ function body(this: Ref): Int
 
 function pre1(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null && this.x == 0
 {
   1
@@ -30,13 +30,13 @@ function pre1(this: Ref): Int
 
 function pre1Abstract(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null && this.x == 0
 
 
 function pre2(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null &&
            this.x == 0
 {
@@ -45,7 +45,7 @@ function pre2(this: Ref): Int
 
 function pre2Abstract(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this != null &&
            this.x == 0
 
@@ -53,7 +53,7 @@ function pre2Abstract(this: Ref): Int
 function pre3(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this.x == 0
 {
   1
@@ -62,18 +62,18 @@ function pre3(this: Ref): Int
 function pre3Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   requires this.x == 0
 
 function post1Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures this.x == 0
 
 function post2Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   ensures this != null &&
           this.x == 0

--- a/src/test/resources/all/issues/silicon/0161.sil
+++ b/src/test/resources/all/issues/silicon/0161.sil
@@ -2,12 +2,14 @@ field x: Int
 
 function pre(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null && this.x == 0
 {
   1
 }
 
 //:: ExpectedOutput(function.not.wellformed:insufficient.permission)
+//:: MissingOutput(function.not.wellformed:insufficient.permission, /dummy/issue/0008/)
 function body(this: Ref): Int
   requires this != null
 {
@@ -20,6 +22,7 @@ function body(this: Ref): Int
 
 function pre1(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null && this.x == 0
 {
   1
@@ -27,11 +30,13 @@ function pre1(this: Ref): Int
 
 function pre1Abstract(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null && this.x == 0
 
 
 function pre2(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null &&
            this.x == 0
 {
@@ -40,6 +45,7 @@ function pre2(this: Ref): Int
 
 function pre2Abstract(this: Ref): Int
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this != null &&
            this.x == 0
 
@@ -47,6 +53,7 @@ function pre2Abstract(this: Ref): Int
 function pre3(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this.x == 0
 {
   1
@@ -55,15 +62,18 @@ function pre3(this: Ref): Int
 function pre3Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   requires this.x == 0
 
 function post1Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures this.x == 0
 
 function post2Abstract(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   ensures this != null &&
           this.x == 0

--- a/src/test/resources/all/issues/silicon/0162.sil
+++ b/src/test/resources/all/issues/silicon/0162.sil
@@ -3,9 +3,11 @@ field x: Int
 function post1(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
   ensures this.x == 0
 {
   1
@@ -14,9 +16,11 @@ function post1(this: Ref): Int
 function post2(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
   ensures this != null &&
           this.x == 0
 {

--- a/src/test/resources/all/issues/silicon/0162.sil
+++ b/src/test/resources/all/issues/silicon/0162.sil
@@ -3,11 +3,11 @@ field x: Int
 function post1(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0003/)
   ensures this.x == 0
 {
   1
@@ -16,11 +16,11 @@ function post1(this: Ref): Int
 function post2(this: Ref): Int
   requires this != null
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   //:: MissingOutput(postcondition.violated:assertion.false, /Carbon/issue/69/)
   //:: MissingOutput(postcondition.violated:assertion.false, /Silicon/issue/162/)
-  //:: MissingOutput(postcondition.violated:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(postcondition.violated:assertion.false, /natrix/issue/0003/)
   ensures this != null &&
           this.x == 0
 {

--- a/src/test/resources/all/issues/silicon/0164.sil
+++ b/src/test/resources/all/issues/silicon/0164.sil
@@ -4,7 +4,7 @@ method loopTrueFalse(this: Ref)
   i := 1
   while (i < 10)
     //:: ExpectedOutput(invariant.not.established:assertion.false)
-    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /dummy/issue/0016/)
+    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /natrix/issue/0016/)
     invariant [true, false]
   {
     i := i + 1

--- a/src/test/resources/all/issues/silicon/0164.sil
+++ b/src/test/resources/all/issues/silicon/0164.sil
@@ -4,6 +4,7 @@ method loopTrueFalse(this: Ref)
   i := 1
   while (i < 10)
     //:: ExpectedOutput(invariant.not.established:assertion.false)
+    //:: UnexpectedOutput(invariant.not.preserved:assertion.false, /dummy/issue/0016/)
     invariant [true, false]
   {
     i := i + 1

--- a/src/test/resources/all/issues/silicon/0165.sil
+++ b/src/test/resources/all/issues/silicon/0165.sil
@@ -8,12 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
-    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /natrix/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
-    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /natrix/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false

--- a/src/test/resources/all/issues/silicon/0165.sil
+++ b/src/test/resources/all/issues/silicon/0165.sil
@@ -8,9 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false

--- a/src/test/resources/all/issues/silicon/unofficial001.sil
+++ b/src/test/resources/all/issues/silicon/unofficial001.sil
@@ -1,7 +1,7 @@
 /* Gist of an issue of Silicon that Uri Juhasz found during our Viper hackathon in Nov'13.
  * See Silicon commit 2198527861b6.
  */
-//:: IgnoreFile(/dummy/issue/0021/)
+//:: IgnoreFile(/natrix/issue/0021/)
 
 field next: Ref
 

--- a/src/test/resources/all/issues/silicon/unofficial001.sil
+++ b/src/test/resources/all/issues/silicon/unofficial001.sil
@@ -1,6 +1,7 @@
 /* Gist of an issue of Silicon that Uri Juhasz found during our Viper hackathon in Nov'13.
  * See Silicon commit 2198527861b6.
  */
+//:: IgnoreFile(/dummy/issue/0021/)
 
 field next: Ref
 

--- a/src/test/resources/all/issues/silver/0003.sil
+++ b/src/test/resources/all/issues/silver/0003.sil
@@ -9,7 +9,7 @@ method t11(r: Ref) returns ()
     while (j < 3)
         //:: ExpectedOutput(not.wellformed:insufficient.permission)
         //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
-        //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+        //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
         //:: ExpectedOutput(invariant.not.established:assertion.false)
         //:: MissingOutput(invariant.not.established:assertion.false, /Silicon/issue/34/)
         invariant r != null && r.f == 2

--- a/src/test/resources/all/issues/silver/0003.sil
+++ b/src/test/resources/all/issues/silver/0003.sil
@@ -9,6 +9,7 @@ method t11(r: Ref) returns ()
     while (j < 3)
         //:: ExpectedOutput(not.wellformed:insufficient.permission)
         //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
+        //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
         //:: ExpectedOutput(invariant.not.established:assertion.false)
         //:: MissingOutput(invariant.not.established:assertion.false, /Silicon/issue/34/)
         invariant r != null && r.f == 2

--- a/src/test/resources/all/issues/silver/0072.sil
+++ b/src/test/resources/all/issues/silver/0072.sil
@@ -16,7 +16,7 @@ method t_minus_1(x: Ref)
     requires acc(x.f)
 {
     //:: ExpectedOutput(fold.failed:negative.permission)
-    //:: MissingOutput(fold.failed:negative.permission, /dummy/issue/0019/)
+    //:: MissingOutput(fold.failed:negative.permission, /natrix/issue/0019/)
     fold acc(token(x), (-1/1))
 }
 
@@ -24,7 +24,7 @@ method t_minus_2(x: Ref)
     requires acc(x.f)
 {
     //:: ExpectedOutput(fold.failed:negative.permission)
-    //:: MissingOutput(fold.failed:negative.permission, /dummy/issue/0019/)
+    //:: MissingOutput(fold.failed:negative.permission, /natrix/issue/0019/)
     fold acc(token(x), -(1/1))
 }
 

--- a/src/test/resources/all/issues/silver/0072.sil
+++ b/src/test/resources/all/issues/silver/0072.sil
@@ -16,6 +16,7 @@ method t_minus_1(x: Ref)
     requires acc(x.f)
 {
     //:: ExpectedOutput(fold.failed:negative.permission)
+    //:: MissingOutput(fold.failed:negative.permission, /dummy/issue/0019/)
     fold acc(token(x), (-1/1))
 }
 
@@ -23,6 +24,7 @@ method t_minus_2(x: Ref)
     requires acc(x.f)
 {
     //:: ExpectedOutput(fold.failed:negative.permission)
+    //:: MissingOutput(fold.failed:negative.permission, /dummy/issue/0019/)
     fold acc(token(x), -(1/1))
 }
 

--- a/src/test/resources/all/issues/silver/0127-2.sil
+++ b/src/test/resources/all/issues/silver/0127-2.sil
@@ -6,5 +6,6 @@ method test01() {
 
 method test02() {
   //:: ExpectedOutput(inhale.failed:insufficient.permission)
+  //:: MissingOutput(inhale.failed:insufficient.permission, /dummy/issue/0019/)
   inhale unfolding P() in true 
 }

--- a/src/test/resources/all/issues/silver/0127-2.sil
+++ b/src/test/resources/all/issues/silver/0127-2.sil
@@ -6,6 +6,6 @@ method test01() {
 
 method test02() {
   //:: ExpectedOutput(inhale.failed:insufficient.permission)
-  //:: MissingOutput(inhale.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(inhale.failed:insufficient.permission, /natrix/issue/0019/)
   inhale unfolding P() in true 
 }

--- a/src/test/resources/all/old/old.sil
+++ b/src/test/resources/all/old/old.sil
@@ -27,6 +27,8 @@ method t3(this: Ref) returns ()
     var r: Ref
     r := new()
     //:: ExpectedOutput(exhale.failed:insufficient.permission)
+    //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
+    //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
     exhale (old(r.f) > 0)
 }
 
@@ -39,6 +41,8 @@ method t4(r: Ref) returns ()
     // we hold no permission to r.f any longer, but old(r.f) is still ok
     exhale (old(r.f) > 0)
     //:: ExpectedOutput(exhale.failed:insufficient.permission)
+    //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
+    //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
     exhale (r.f) > 0
 }
 

--- a/src/test/resources/all/old/old.sil
+++ b/src/test/resources/all/old/old.sil
@@ -27,8 +27,8 @@ method t3(this: Ref) returns ()
     var r: Ref
     r := new()
     //:: ExpectedOutput(exhale.failed:insufficient.permission)
-    //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
-    //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
+    //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0002/)
+    //:: UnexpectedOutput(exhale.failed:assertion.false, /natrix/issue/0002/)
     exhale (old(r.f) > 0)
 }
 
@@ -41,8 +41,8 @@ method t4(r: Ref) returns ()
     // we hold no permission to r.f any longer, but old(r.f) is still ok
     exhale (old(r.f) > 0)
     //:: ExpectedOutput(exhale.failed:insufficient.permission)
-    //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0002/)
-    //:: UnexpectedOutput(exhale.failed:assertion.false, /dummy/issue/0002/)
+    //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0002/)
+    //:: UnexpectedOutput(exhale.failed:assertion.false, /natrix/issue/0002/)
     exhale (r.f) > 0
 }
 

--- a/src/test/resources/all/permissions/framing_none_perms.sil
+++ b/src/test/resources/all/permissions/framing_none_perms.sil
@@ -11,7 +11,7 @@ method test01(x: Ref, y: Ref)
   y.f := 0
   assert vx == fun01(x, y, true)
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert vy == fun01(x, y, false)
 }
 
@@ -29,6 +29,6 @@ method test02(x: Ref, y: Ref)
   assert vx == fun02(x, y, true)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/34/)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert vy == fun02(x, y, false)
 }

--- a/src/test/resources/all/permissions/framing_none_perms.sil
+++ b/src/test/resources/all/permissions/framing_none_perms.sil
@@ -11,6 +11,7 @@ method test01(x: Ref, y: Ref)
   y.f := 0
   assert vx == fun01(x, y, true)
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert vy == fun01(x, y, false)
 }
 
@@ -28,5 +29,6 @@ method test02(x: Ref, y: Ref)
   assert vx == fun02(x, y, true)
   //:: ExpectedOutput(assert.failed:assertion.false)
   //:: MissingOutput(assert.failed:assertion.false, /silicon/issue/34/)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert vy == fun02(x, y, false)
 }

--- a/src/test/resources/all/permissions/loops.sil
+++ b/src/test/resources/all/permissions/loops.sil
@@ -8,9 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false
@@ -30,6 +33,7 @@ method test3(x: Ref)
   requires acc(x.f)
 {
   //:: ExpectedOutput(while.failed:insufficient.permission)
+  //:: MissingOutput(while.failed:insufficient.permission, /dummy/issue/0008/)
   while (x.f < 3)
   {
   }

--- a/src/test/resources/all/permissions/loops.sil
+++ b/src/test/resources/all/permissions/loops.sil
@@ -8,12 +8,12 @@ method test(x: Ref)
   while (b)
     //:: ExpectedOutput(not.wellformed:insufficient.permission)
     //:: MissingOutput(not.wellformed:insufficient.permission, /Carbon/issue/70/)
-    //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0008/)
-    //:: UnexpectedOutput(invariant.not.established:assertion.false, /dummy/issue/0008/)
+    //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0008/)
+    //:: UnexpectedOutput(invariant.not.established:assertion.false, /natrix/issue/0008/)
     invariant x != null && x.f != 3 // This is not self-framing.
   {
     //:: UnexpectedOutput(assignment.failed:insufficient.permission, /Carbon/issue/70/)
-    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /dummy/issue/0008/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /natrix/issue/0008/)
     x.f := 4  // Loop body should be verified under assumption that invariant
               // is wellformed.
     b := false
@@ -33,7 +33,7 @@ method test3(x: Ref)
   requires acc(x.f)
 {
   //:: ExpectedOutput(while.failed:insufficient.permission)
-  //:: MissingOutput(while.failed:insufficient.permission, /dummy/issue/0008/)
+  //:: MissingOutput(while.failed:insufficient.permission, /natrix/issue/0008/)
   while (x.f < 3)
   {
   }

--- a/src/test/resources/all/predicates/arguments.sil
+++ b/src/test/resources/all/predicates/arguments.sil
@@ -41,6 +41,7 @@ method t2b(this: Ref)
     ensures acc(valid(this, true), write)
 {
     //:: ExpectedOutput(fold.failed:insufficient.permission)
+    //:: MissingOutput(fold.failed:insufficient.permission, /dummy/issue/0019/)
     fold acc(valid(this, false), write)
 }
 
@@ -51,6 +52,7 @@ method t3(this: Ref, b: Bool)
     //:: UnexpectedOutput(not.wellformed:insufficient.permission, /silicon/issue/36/)
     requires (unfolding acc(valid(this, false), write) in ((this.g) == 2))
     ensures acc(valid(this, b), write)
+    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /dummy/issue/0020/)
     ensures acc(valid(this, !b), write)
     ensures (unfolding acc(valid(this, false), write) in ((this.g) == 2))
 {
@@ -66,6 +68,7 @@ method t3a(this: Ref, b: Bool)
     //:: UnexpectedOutput(not.wellformed:insufficient.permission, /silicon/issue/36/)
     requires (unfolding acc(valid(this, false), write) in ((this.g) == 2))
     ensures acc(valid(this, b), write)
+    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /dummy/issue/0020/)
     ensures acc(valid(this, !b), write)
     ensures (unfolding acc(valid(this, false), write) in ((this.g) == 2))
 {
@@ -83,5 +86,6 @@ method t3b(this: Ref, b: Bool)
     unfold acc(valid(this, true), write)
     //:: ExpectedOutput(assignment.failed:insufficient.permission)
     //:: MissingOutput(assignment.failed:insufficient.permission, /silicon/issue/36/)
+    //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
     this.g := 1
 }

--- a/src/test/resources/all/predicates/arguments.sil
+++ b/src/test/resources/all/predicates/arguments.sil
@@ -41,7 +41,7 @@ method t2b(this: Ref)
     ensures acc(valid(this, true), write)
 {
     //:: ExpectedOutput(fold.failed:insufficient.permission)
-    //:: MissingOutput(fold.failed:insufficient.permission, /dummy/issue/0019/)
+    //:: MissingOutput(fold.failed:insufficient.permission, /natrix/issue/0019/)
     fold acc(valid(this, false), write)
 }
 
@@ -52,7 +52,7 @@ method t3(this: Ref, b: Bool)
     //:: UnexpectedOutput(not.wellformed:insufficient.permission, /silicon/issue/36/)
     requires (unfolding acc(valid(this, false), write) in ((this.g) == 2))
     ensures acc(valid(this, b), write)
-    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /dummy/issue/0020/)
+    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /natrix/issue/0020/)
     ensures acc(valid(this, !b), write)
     ensures (unfolding acc(valid(this, false), write) in ((this.g) == 2))
 {
@@ -68,7 +68,7 @@ method t3a(this: Ref, b: Bool)
     //:: UnexpectedOutput(not.wellformed:insufficient.permission, /silicon/issue/36/)
     requires (unfolding acc(valid(this, false), write) in ((this.g) == 2))
     ensures acc(valid(this, b), write)
-    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /dummy/issue/0020/)
+    //:: UnexpectedOutput(postcondition.violated:insufficient.permission, /natrix/issue/0020/)
     ensures acc(valid(this, !b), write)
     ensures (unfolding acc(valid(this, false), write) in ((this.g) == 2))
 {
@@ -86,6 +86,6 @@ method t3b(this: Ref, b: Bool)
     unfold acc(valid(this, true), write)
     //:: ExpectedOutput(assignment.failed:insufficient.permission)
     //:: MissingOutput(assignment.failed:insufficient.permission, /silicon/issue/36/)
-    //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+    //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
     this.g := 1
 }

--- a/src/test/resources/all/predicates/lseg.sil
+++ b/src/test/resources/all/predicates/lseg.sil
@@ -1,4 +1,4 @@
-//:: IgnoreFile(/dummy/issue/000/)
+//:: IgnoreFile(/natrix/issue/0021/)
 field next: Ref
 field value: Int
 

--- a/src/test/resources/all/predicates/lseg.sil
+++ b/src/test/resources/all/predicates/lseg.sil
@@ -1,3 +1,4 @@
+//:: IgnoreFile(/dummy/issue/000/)
 field next: Ref
 field value: Int
 

--- a/src/test/resources/all/predicates/non-aliasing.sil
+++ b/src/test/resources/all/predicates/non-aliasing.sil
@@ -12,6 +12,6 @@ method t1(r1: Ref, r2: Ref, b: Bool)
   requires acc(valid(false, r1, r2), write)
 {
   unfold acc(valid(false, r1, r2), write)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0020/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0020/)
   assert (r2 != (r2.f))
 }

--- a/src/test/resources/all/predicates/non-aliasing.sil
+++ b/src/test/resources/all/predicates/non-aliasing.sil
@@ -12,5 +12,6 @@ method t1(r1: Ref, r2: Ref, b: Bool)
   requires acc(valid(false, r1, r2), write)
 {
   unfold acc(valid(false, r1, r2), write)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0020/)
   assert (r2 != (r2.f))
 }

--- a/src/test/resources/all/predicates/receiverless.sil
+++ b/src/test/resources/all/predicates/receiverless.sil
@@ -6,6 +6,7 @@ method t1(this: Ref, b: Bool)
     requires acc(valid(false), write)
 {
     //:: ExpectedOutput(assert.failed:assertion.false)
+    //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0019/)
     assert false
 }
 

--- a/src/test/resources/all/predicates/receiverless.sil
+++ b/src/test/resources/all/predicates/receiverless.sil
@@ -6,7 +6,7 @@ method t1(this: Ref, b: Bool)
     requires acc(valid(false), write)
 {
     //:: ExpectedOutput(assert.failed:assertion.false)
-    //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0019/)
+    //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0019/)
     assert false
 }
 

--- a/src/test/resources/all/predicates/unfolding.sil
+++ b/src/test/resources/all/predicates/unfolding.sil
@@ -10,6 +10,7 @@ method fail10(this: Ref)
   requires acc(P(this), write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
   ensures unfolding P(this) in this.x == old(this.x)
 {
 }
@@ -33,6 +34,7 @@ method fail5(this: Ref)
   requires acc(P(this), write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
   ensures unfolding P(this) in this.x == old(this.x) + 1
 {
   unfold P(this)
@@ -66,6 +68,7 @@ method fail1(this: Ref)
   requires acc(this.x, write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
   ensures (unfolding acc(P(this), write) in this.x == old((unfolding acc(P(this), write) in this.x)))
 {
   fold acc(P(this), write)

--- a/src/test/resources/all/predicates/unfolding.sil
+++ b/src/test/resources/all/predicates/unfolding.sil
@@ -10,7 +10,7 @@ method fail10(this: Ref)
   requires acc(P(this), write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0019/)
   ensures unfolding P(this) in this.x == old(this.x)
 {
 }
@@ -34,7 +34,7 @@ method fail5(this: Ref)
   requires acc(P(this), write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0019/)
   ensures unfolding P(this) in this.x == old(this.x) + 1
 {
   unfold P(this)
@@ -68,7 +68,7 @@ method fail1(this: Ref)
   requires acc(this.x, write)
   ensures acc(P(this), write)
   //:: ExpectedOutput(not.wellformed:insufficient.permission)
-  //:: MissingOutput(not.wellformed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(not.wellformed:insufficient.permission, /natrix/issue/0019/)
   ensures (unfolding acc(P(this), write) in this.x == old((unfolding acc(P(this), write) in this.x)))
 {
   fold acc(P(this), write)

--- a/src/test/resources/all/predicates/unfolding_exhale.sil
+++ b/src/test/resources/all/predicates/unfolding_exhale.sil
@@ -10,7 +10,7 @@ method fail10(this: Ref)
   requires acc(P(this), write)
 {
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
-  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0019/)
   exhale acc(P(this), write) && unfolding P(this) in this.x == old(this.x)
 }
 
@@ -34,7 +34,7 @@ method fail5(this: Ref)
   this.x := this.x + 1
   fold P(this)
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
-  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0019/)
   exhale acc(P(this), write) && unfolding P(this) in this.x == old(this.x) + 1
 }
 
@@ -63,7 +63,7 @@ method fail1(this: Ref)
 {
   fold acc(P(this), write)
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
-  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /natrix/issue/0019/)
   exhale  acc(P(this), write) && (unfolding acc(P(this), write) in this.x == old((unfolding acc(P(this), write) in this.x)))
 }
 

--- a/src/test/resources/all/predicates/unfolding_exhale.sil
+++ b/src/test/resources/all/predicates/unfolding_exhale.sil
@@ -10,6 +10,7 @@ method fail10(this: Ref)
   requires acc(P(this), write)
 {
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
   exhale acc(P(this), write) && unfolding P(this) in this.x == old(this.x)
 }
 
@@ -33,6 +34,7 @@ method fail5(this: Ref)
   this.x := this.x + 1
   fold P(this)
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
   exhale acc(P(this), write) && unfolding P(this) in this.x == old(this.x) + 1
 }
 
@@ -61,6 +63,7 @@ method fail1(this: Ref)
 {
   fold acc(P(this), write)
   //:: ExpectedOutput(exhale.failed:insufficient.permission)
+  //:: MissingOutput(exhale.failed:insufficient.permission, /dummy/issue/0019/)
   exhale  acc(P(this), write) && (unfolding acc(P(this), write) in this.x == old((unfolding acc(P(this), write) in this.x)))
 }
 

--- a/src/test/resources/all/third_party/stefan_recent/testHistoryLemmasPVL.sil
+++ b/src/test/resources/all/third_party/stefan_recent/testHistoryLemmasPVL.sil
@@ -41,7 +41,7 @@ method History__lemma(diz: Ref, current_thread_id: Int, n: Int)
   requires diz != null
   requires current_thread_id >= 0
   requires n >= 0
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0020/)
   ensures p_single(n) == (n > 0 ? p_seq(p_single(n - 1), p_incr()) : p_empty())
 {
   var if_any_bool: Bool

--- a/src/test/resources/all/third_party/stefan_recent/testHistoryLemmasPVL.sil
+++ b/src/test/resources/all/third_party/stefan_recent/testHistoryLemmasPVL.sil
@@ -41,6 +41,7 @@ method History__lemma(diz: Ref, current_thread_id: Int, n: Int)
   requires diz != null
   requires current_thread_id >= 0
   requires n >= 0
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
   ensures p_single(n) == (n > 0 ? p_seq(p_single(n - 1), p_incr()) : p_empty())
 {
   var if_any_bool: Bool

--- a/src/test/resources/all/third_party/stefan_recent/testHistoryThreadsLemmasPVL.sil
+++ b/src/test/resources/all/third_party/stefan_recent/testHistoryThreadsLemmasPVL.sil
@@ -41,7 +41,7 @@ method History__lemma(diz: Ref, current_thread_id: Int, n: Int)
   requires diz != null
   requires current_thread_id >= 0
   requires n >= 0
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0020/)
   ensures p_single(n) == (n > 0 ? p_seq(p_single(n - 1), p_incr()) : p_empty())
 {
   var if_any_bool: Bool

--- a/src/test/resources/all/third_party/stefan_recent/testHistoryThreadsLemmasPVL.sil
+++ b/src/test/resources/all/third_party/stefan_recent/testHistoryThreadsLemmasPVL.sil
@@ -41,6 +41,7 @@ method History__lemma(diz: Ref, current_thread_id: Int, n: Int)
   requires diz != null
   requires current_thread_id >= 0
   requires n >= 0
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
   ensures p_single(n) == (n > 0 ? p_seq(p_single(n - 1), p_incr()) : p_empty())
 {
   var if_any_bool: Bool

--- a/src/test/resources/quantifiedpermissions/issues/issue_0085.sil
+++ b/src/test/resources/quantifiedpermissions/issues/issue_0085.sil
@@ -12,5 +12,6 @@ method m2(this: Ref, xs: Set[Ref])
   fold acc(inv(this))
 
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
   this.n := xs
 }

--- a/src/test/resources/quantifiedpermissions/issues/issue_0085.sil
+++ b/src/test/resources/quantifiedpermissions/issues/issue_0085.sil
@@ -12,6 +12,6 @@ method m2(this: Ref, xs: Set[Ref])
   fold acc(inv(this))
 
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
-  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
   this.n := xs
 }

--- a/src/test/resources/quantifiedpermissions/issues/issue_0085a.sil
+++ b/src/test/resources/quantifiedpermissions/issues/issue_0085a.sil
@@ -10,6 +10,7 @@ method m0(this: Ref)
   requires acc(P(this))
 {
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
   this.n := this.n
 }
 
@@ -20,6 +21,7 @@ method m1(this: Ref)
   fold acc(P(this))
 
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
   this.n := this.n
 }
 
@@ -34,5 +36,6 @@ method m2(this: Ref, xs: Set[Ref])
   fold acc(inv(this))
   
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
   this.n := xs
 }

--- a/src/test/resources/quantifiedpermissions/issues/issue_0085a.sil
+++ b/src/test/resources/quantifiedpermissions/issues/issue_0085a.sil
@@ -10,7 +10,7 @@ method m0(this: Ref)
   requires acc(P(this))
 {
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
-  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
   this.n := this.n
 }
 
@@ -21,7 +21,7 @@ method m1(this: Ref)
   fold acc(P(this))
 
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
-  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
   this.n := this.n
 }
 
@@ -36,6 +36,6 @@ method m2(this: Ref, xs: Set[Ref])
   fold acc(inv(this))
   
   //:: ExpectedOutput(assignment.failed:insufficient.permission)
-  //:: MissingOutput(assignment.failed:insufficient.permission, /dummy/issue/0019/)
+  //:: MissingOutput(assignment.failed:insufficient.permission, /natrix/issue/0019/)
   this.n := xs
 }

--- a/src/test/resources/quantifiedpermissions/issues/unofficial_0002.sil
+++ b/src/test/resources/quantifiedpermissions/issues/unofficial_0002.sil
@@ -23,7 +23,7 @@ method trav(graph: Set[Ref], node: Ref)
 		trav(graph, node.left)
 	}
 	//:: ExpectedOutput(assert.failed:insufficient.permission)
-	//:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0014/)
+	//:: MissingOutput(assert.failed:insufficient.permission, /natrix/issue/0014/)
   assert node.is_marked; /* Previously succeeded */
 }
 

--- a/src/test/resources/quantifiedpermissions/issues/unofficial_0002.sil
+++ b/src/test/resources/quantifiedpermissions/issues/unofficial_0002.sil
@@ -23,6 +23,7 @@ method trav(graph: Set[Ref], node: Ref)
 		trav(graph, node.left)
 	}
 	//:: ExpectedOutput(assert.failed:insufficient.permission)
+	//:: MissingOutput(assert.failed:insufficient.permission, /dummy/issue/0014/)
   assert node.is_marked; /* Previously succeeded */
 }
 

--- a/src/test/resources/quantifiedpermissions/misc/countfalse.sil
+++ b/src/test/resources/quantifiedpermissions/misc/countfalse.sil
@@ -9,6 +9,7 @@ method lemmaFrontX(a: Array, from: Int)
   requires 0 <= from && from <= length(a);
   requires forall z: Int :: (from <= z && z < length(a) ==> acc(loc(a,z).val));
 {
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert
     countFalseX(a, from)
       ==
@@ -19,6 +20,7 @@ method lemmaFrontXX(a: Array, from: Int)
   requires 0 <= from && from <= length(a);
   requires forall z: Int :: (from <= z && z < length(a) ==> acc(loc(a,z).val));
 {
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert
     countFalseX(a, from)
       ==
@@ -43,6 +45,7 @@ method lemmaFront(a: Array, from: Int, to: Int)
   requires forall z: Int :: (from <= z && z < to ==> acc(loc(a,z).val));
 {
   /* Previously failed */
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert
     countFalse(a, from, to)
       ==

--- a/src/test/resources/quantifiedpermissions/misc/countfalse.sil
+++ b/src/test/resources/quantifiedpermissions/misc/countfalse.sil
@@ -9,7 +9,7 @@ method lemmaFrontX(a: Array, from: Int)
   requires 0 <= from && from <= length(a);
   requires forall z: Int :: (from <= z && z < length(a) ==> acc(loc(a,z).val));
 {
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert
     countFalseX(a, from)
       ==
@@ -20,7 +20,7 @@ method lemmaFrontXX(a: Array, from: Int)
   requires 0 <= from && from <= length(a);
   requires forall z: Int :: (from <= z && z < length(a) ==> acc(loc(a,z).val));
 {
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert
     countFalseX(a, from)
       ==
@@ -45,7 +45,7 @@ method lemmaFront(a: Array, from: Int, to: Int)
   requires forall z: Int :: (from <= z && z < to ==> acc(loc(a,z).val));
 {
   /* Previously failed */
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert
     countFalse(a, from, to)
       ==

--- a/src/test/resources/quantifiedpermissions/sets/consumepureforall.sil
+++ b/src/test/resources/quantifiedpermissions/sets/consumepureforall.sil
@@ -78,6 +78,7 @@ method m8(S: Set[Ref], b: Ref, a :Int, c: Ref)
   requires c.f < 0
   requires a > 0
   ensures forall r : Ref :: r in S ==> acc(r.f)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
   ensures forall t : Ref :: t in S ==> (t.f == ((t == b) ? 2*a+1 : a))
 {
   b.f := 2*a+1

--- a/src/test/resources/quantifiedpermissions/sets/consumepureforall.sil
+++ b/src/test/resources/quantifiedpermissions/sets/consumepureforall.sil
@@ -78,7 +78,7 @@ method m8(S: Set[Ref], b: Ref, a :Int, c: Ref)
   requires c.f < 0
   requires a > 0
   ensures forall r : Ref :: r in S ==> acc(r.f)
-  //:: UnexpectedOutput(postcondition.violated:assertion.false, /dummy/issue/0020/)
+  //:: UnexpectedOutput(postcondition.violated:assertion.false, /natrix/issue/0020/)
   ensures forall t : Ref :: t in S ==> (t.f == ((t == b) ? 2*a+1 : a))
 {
   b.f := 2*a+1

--- a/src/test/resources/quantifiedpermissions/sets/snapshots2.sil
+++ b/src/test/resources/quantifiedpermissions/sets/snapshots2.sil
@@ -41,7 +41,7 @@ method test05(xs: Set[Ref], x: Ref, y: Ref, n: Int)
 {
   var v: Int := fun(xs, x, n)
   y.f := y.f
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -55,7 +55,7 @@ method test06(xs: Set[Ref], x: Ref, y: Ref, n: Int)
   var yf: Int := y.f
   y.f := 0
   y.f := yf
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -68,7 +68,7 @@ method test07(xs: Set[Ref], x: Ref, y: Ref, n: Int)
   var v: Int := fun(xs, x, n)
   y.f := 0
   y.f := old(y.f)
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -80,7 +80,7 @@ method test03(xs: Set[Ref], x: Ref, y: Ref, n: Int)
 {
   var v: Int := fun(xs, x, 0)
   y.f := 0
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0003/)
   assert v == fun(xs, x, 0)
 }
 
@@ -92,7 +92,7 @@ method test04(xs: Set[Ref], ys: Set[Ref], x: Ref, y: Ref, n: Int)
   requires n >= 0
 {
   /* TODO: Should not be necessary, see silicon/issues/61/ */
-  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /natrix/issue/0023/)
   assert forall z: Ref :: {z in (xs union ys)}{z in xs} z in (xs union ys) ==> z != null
   var v: Int := fun(xs, x, n)
   y.f := 0

--- a/src/test/resources/quantifiedpermissions/sets/snapshots2.sil
+++ b/src/test/resources/quantifiedpermissions/sets/snapshots2.sil
@@ -41,6 +41,7 @@ method test05(xs: Set[Ref], x: Ref, y: Ref, n: Int)
 {
   var v: Int := fun(xs, x, n)
   y.f := y.f
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -54,6 +55,7 @@ method test06(xs: Set[Ref], x: Ref, y: Ref, n: Int)
   var yf: Int := y.f
   y.f := 0
   y.f := yf
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -66,6 +68,7 @@ method test07(xs: Set[Ref], x: Ref, y: Ref, n: Int)
   var v: Int := fun(xs, x, n)
   y.f := 0
   y.f := old(y.f)
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert v == fun(xs, x, n)
 }
 
@@ -77,6 +80,7 @@ method test03(xs: Set[Ref], x: Ref, y: Ref, n: Int)
 {
   var v: Int := fun(xs, x, 0)
   y.f := 0
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0003/)
   assert v == fun(xs, x, 0)
 }
 
@@ -88,6 +92,7 @@ method test04(xs: Set[Ref], ys: Set[Ref], x: Ref, y: Ref, n: Int)
   requires n >= 0
 {
   /* TODO: Should not be necessary, see silicon/issues/61/ */
+  //:: UnexpectedOutput(assert.failed:assertion.false, /dummy/issue/0023/)
   assert forall z: Ref :: {z in (xs union ys)}{z in xs} z in (xs union ys) ==> z != null
   var v: Int := fun(xs, x, n)
   y.f := 0

--- a/src/test/resources/quantifiedpermissions/sets/snapshots3.sil
+++ b/src/test/resources/quantifiedpermissions/sets/snapshots3.sil
@@ -42,6 +42,8 @@ method m1(this: Ref)
 	unfold acc(P(this.n))
 
   //:: ExpectedOutput(assert.failed:assertion.false)
+  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0014/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0014/)
 	assert a == t.f
 }
 

--- a/src/test/resources/quantifiedpermissions/sets/snapshots3.sil
+++ b/src/test/resources/quantifiedpermissions/sets/snapshots3.sil
@@ -42,8 +42,8 @@ method m1(this: Ref)
 	unfold acc(P(this.n))
 
   //:: ExpectedOutput(assert.failed:assertion.false)
-  //:: MissingOutput(assert.failed:assertion.false, /dummy/issue/0014/)
-  //:: UnexpectedOutput(assert.failed:insufficient.permission, /dummy/issue/0014/)
+  //:: MissingOutput(assert.failed:assertion.false, /natrix/issue/0014/)
+  //:: UnexpectedOutput(assert.failed:insufficient.permission, /natrix/issue/0014/)
 	assert a == t.f
 }
 


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by bitbucket user **a_helfenstein** on 2016-09-06 19:03
> Last updated on 2020-02-18 08:49
> Original Bitbucket pull request id: 58
>
> Participants:
>
> * **@mschwerhoff**
>
> Source: https://github.com/viperproject/silver/commit/f0cfd8a27ea8c1ac3101f808359adaaf283f4d34 on branch `a_helfenstein/silver/default`
> Destination: https://github.com/viperproject/silver/commit/a384ea0d54848d0cf48c2dc7051a7ec63235e8c7 on branch `master`
>
> State: **`OPEN`**

* Test annotations for Grasshopper as Viper Backend Project

* Test annotations for Natrix, tool renaming
