### PR TITLE
Introducing Plugin Aware Reporting

### DIFF
--- a/src/main/scala/viper/silver/frontend/Frontend.scala
+++ b/src/main/scala/viper/silver/frontend/Frontend.scala
@@ -13,7 +13,8 @@ import ch.qos.logback.classic.Logger
 
 import scala.io.Source
 import viper.silver.ast._
-import viper.silver.reporter.{Reporter, StdIOReporter}
+import viper.silver.plugin.PluginAwareReporter
+import viper.silver.reporter.StdIOReporter
 import viper.silver.verifier._
 
 
@@ -49,7 +50,7 @@ trait Frontend {
     *
     * @see <a href="https://bitbucket.org/viperproject/viperserver/src">ViperServer</a> for more details.
     */
-  val reporter: Reporter = StdIOReporter()
+  val reporter: PluginAwareReporter = PluginAwareReporter(StdIOReporter())
 
   /**
     * Run the verification on the input and return the result.  This is equivalent to calling all the phases and then
@@ -185,8 +186,6 @@ trait DefaultFrontend extends Frontend with DefaultPhases with SingleFileFronten
     resetMessages()
   }
 
-  protected def mapVerificationResult(in: VerificationResult): VerificationResult
-
   protected def doParsing(input: String): Result[ParsingResult]
 
   protected def doSemanticAnalysis(input: ParsingResult): Result[SemanticAnalysisResult]
@@ -239,7 +238,7 @@ trait DefaultFrontend extends Frontend with DefaultPhases with SingleFileFronten
 
   override def verification() = {
     if (state == DefaultStates.ConsistencyCheck && _errors.isEmpty) {
-      _verificationResult = Some(mapVerificationResult(_verifier.get.verify(_program.get)))
+      _verificationResult = Some(_verifier.get.verify(_program.get))
       assert(_verificationResult.isDefined)
       _state = DefaultStates.Verification
     }

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -120,6 +120,12 @@ trait SilFrontend extends DefaultFrontend {
     if (_config.dependencies()) {
       reporter report ExternalDependenciesReport(_ver.dependencies)
     }
+
+    // FIXME The error transformer function may not be immutable with current design:
+    // FIXME  `reporter` is a field of trait Frontend, whereas the plugin manager
+    // FIXME  stored in `_plugins` is only initialized here, in SilFrontend.
+    // FIXME  Consider refactoring this part. --- ATG 2019
+    reporter.transform = _plugins.mapVerificationResult
     true
   }
 
@@ -161,7 +167,7 @@ trait SilFrontend extends DefaultFrontend {
 
     if(_config != null) {
       // reset error messages of plugins
-      _plugins = SilverPluginManager(_config.plugin.toOption)(reporter, logger, _config)
+      _plugins = SilverPluginManager(_config.plugin.toOption)(reporter.reporter, logger, _config)
     }
 
     FastPositions.reset()
@@ -297,6 +303,4 @@ trait SilFrontend extends DefaultFrontend {
     else
       Fail(errors)
   }
-
-  override def mapVerificationResult(in: VerificationResult): VerificationResult = _plugins.mapVerificationResult(in)
 }

--- a/src/main/scala/viper/silver/plugin/PluginAwareReporter.scala
+++ b/src/main/scala/viper/silver/plugin/PluginAwareReporter.scala
@@ -3,6 +3,8 @@ package viper.silver.plugin
 import viper.silver.reporter._
 import viper.silver.verifier.{Success, VerificationResult}
 
+
+// TODO consider implementing caching for verification results that were already mapped before.
 case class PluginAwareReporter(reporter: Reporter) {
 
   var transform: Function[VerificationResult, VerificationResult] = identity
@@ -11,12 +13,16 @@ case class PluginAwareReporter(reporter: Reporter) {
     val transformedMsg =
       msg match {
         case OverallFailureMessage(ver, time, res) =>
+//          println(s"--- PluginAwareReporter::report   transform($res) = ${transform(res)}")
           VerificationResultMessage(ver, time, transform(res))
         case OverallSuccessMessage(ver, time) =>
+//          println(s"--- PluginAwareReporter::report   transform(Success) = ${transform(Success)}")
           VerificationResultMessage(ver, time, transform(Success))
         case EntityFailureMessage(ver, ent, time, res) =>
+//          println(s"--- PluginAwareReporter::report   transform($res) = ${transform(res)}")
           VerificationResultMessage(ver, ent, time, transform(res))
         case EntitySuccessMessage(ver, ent, time) =>
+//          println(s"--- PluginAwareReporter::report   transform(Success) = ${transform(Success)}")
           VerificationResultMessage(ver, ent, time, transform(Success))
         case _ => msg
       }

--- a/src/main/scala/viper/silver/plugin/PluginAwareReporter.scala
+++ b/src/main/scala/viper/silver/plugin/PluginAwareReporter.scala
@@ -1,0 +1,25 @@
+package viper.silver.plugin
+
+import viper.silver.reporter._
+import viper.silver.verifier.{Success, VerificationResult}
+
+case class PluginAwareReporter(reporter: Reporter) {
+
+  var transform: Function[VerificationResult, VerificationResult] = identity
+
+  def report(msg: viper.silver.reporter.Message): Unit = {
+    val transformedMsg =
+      msg match {
+        case OverallFailureMessage(ver, time, res) =>
+          VerificationResultMessage(ver, time, transform(res))
+        case OverallSuccessMessage(ver, time) =>
+          VerificationResultMessage(ver, time, transform(Success))
+        case EntityFailureMessage(ver, ent, time, res) =>
+          VerificationResultMessage(ver, ent, time, transform(res))
+        case EntitySuccessMessage(ver, ent, time) =>
+          VerificationResultMessage(ver, ent, time, transform(Success))
+        case _ => msg
+      }
+    reporter report transformedMsg
+  }
+}

--- a/src/test/scala/IOTests.scala
+++ b/src/test/scala/IOTests.scala
@@ -10,6 +10,7 @@ import java.nio.file.Paths
 import org.scalatest.{FunSuite, Matchers}
 import viper.silver.ast.{NoPosition, Position, Program}
 import viper.silver.frontend.{SilFrontend, SilFrontendConfig}
+import viper.silver.plugin.PluginAwareReporter
 import viper.silver.reporter.StdIOReporter
 import viper.silver.verifier.errors.ErrorNode
 import viper.silver.verifier._
@@ -127,7 +128,7 @@ class IOTests extends FunSuite with Matchers {
       instance.config
     }
 
-    override val reporter = StdIOReporter("MockStdIOReporter")
+    override val reporter = PluginAwareReporter(StdIOReporter("MockStdIOReporter"))
   }
 
   class MockIOVerifier(val pass: Boolean) extends Verifier {


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by **@aterga** on 2019-05-26 13:18
> Last updated on 2020-02-18 08:49
> Original Bitbucket pull request id: 120
>
> Participants:
>
> * **@aterga**
> * **@mschwerhoff** (reviewer) :heavy_check_mark:
>
> Source: https://github.com/viperproject/silver/commit/010564107299efff441fee7a6256c88308210fb1 on branch `arshavir/silver-plugin-aware-reporting/default`
> Destination: https://github.com/viperproject/silver/commit/a384ea0d54848d0cf48c2dc7051a7ec63235e8c7 on branch `master`
>
> State: **`OPEN`**

This series of pull requests introduces an improvement to the reporting mechanism that properly maps verification results according to the hook definition from an arbitrary set of plugins. Before, this mapping only happened as a post-verification phase in SilFrontend, and the dynamically reported verification results have not been covered. 

Now, the package viper.silver.plugin provides a new class PluginAwareReporter that will lazily transform the verification results as specified by the plugins. This new type replaces the standard Reporter interface in all places in Silver \(except SilverPluginManager, where the old Reporter type is used for security reasons\).
