### PR TITLE
add info kind for attaching AST nodes to other nodes

### DIFF
--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -7,7 +7,7 @@
 package viper.silver.ast
 
 import scala.reflect.ClassTag
-import pretty.FastPrettyPrinter
+import pretty.{FastPrettyPrinter, PrettyPrintingConfig}
 import utility._
 import viper.silver.ast.utility.rewriter.Traverse.Traverse
 import viper.silver.ast.utility.rewriter.{Rewritable, StrategyBuilder, Traverse}
@@ -339,6 +339,13 @@ case object NoInfo extends Info {
 /** A simple `Info` that contains a list of comments. */
 case class SimpleInfo(comment: Seq[String]) extends Info {
   lazy val isCached = false
+}
+
+/** An `Info` instance for attaching AST nodes to a term. */
+case class AstAttachmentInfo(description: String, nodes: Seq[Node]) extends Info {
+  override def comment: Seq[String] =
+    if (PrettyPrintingConfig.printAstAttachments) nodes.map(description ++ _.toString()) else Nil
+  override lazy val isCached = false
 }
 
 /** An `Info` instance for labelling a quantifier as auto-triggered. */

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -7,7 +7,7 @@
 package viper.silver.ast
 
 import scala.reflect.ClassTag
-import pretty.{FastPrettyPrinter, PrettyPrintingConfig}
+import pretty.FastPrettyPrinter
 import utility._
 import viper.silver.ast.utility.rewriter.Traverse.Traverse
 import viper.silver.ast.utility.rewriter.{Rewritable, StrategyBuilder, Traverse}
@@ -339,13 +339,6 @@ case object NoInfo extends Info {
 /** A simple `Info` that contains a list of comments. */
 case class SimpleInfo(comment: Seq[String]) extends Info {
   lazy val isCached = false
-}
-
-/** An `Info` instance for attaching AST nodes to a term. */
-case class AstAttachmentInfo(description: String, nodes: Seq[Node]) extends Info {
-  override def comment: Seq[String] =
-    if (PrettyPrintingConfig.printAstAttachments) nodes.map(description ++ _.toString()) else Nil
-  override lazy val isCached = false
 }
 
 /** An `Info` instance for labelling a quantifier as auto-triggered. */

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -455,6 +455,14 @@ trait BracketPrettyPrinter extends FastPrettyPrinterBase {
   }
 }
 
+object PrettyPrintingConfig {
+  /**
+   * Indicates whether AST nodes that are attached to a node should be printed as comments.
+   * @see [[viper.silver.ast.AstAttachmentInfo]]
+   */
+  var printAstAttachments = false
+}
+
 /**
   * Pretty printer for the Silver language
   */
@@ -569,7 +577,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     if (contracts == null)
       line <> name <+> uninitialized
     else
-      lineIfSomeNonEmpty(contracts) <> ssep(contracts map (text(name) <+> show(_)), line)
+      lineIfSomeNonEmpty(contracts) <> ssep(contracts map (e => showComment(e) <@> text(name) <+> show(e)), line)
   }
 
   /** Returns `n` lines if at least one element of `s` is non-empty, and an empty document otherwise. */

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -455,14 +455,6 @@ trait BracketPrettyPrinter extends FastPrettyPrinterBase {
   }
 }
 
-object PrettyPrintingConfig {
-  /**
-   * Indicates whether AST nodes that are attached to a node should be printed as comments.
-   * @see [[viper.silver.ast.AstAttachmentInfo]]
-   */
-  var printAstAttachments = false
-}
-
 /**
   * Pretty printer for the Silver language
   */


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by bitbucket user **nilsbecker_** on 2019-12-10 17:29
> Last updated on 2020-02-18 08:49
> Original Bitbucket pull request id: 135
>
> Participants:
>
> * **@alexanderjsummers** (reviewer)
> * bitbucket user **nilsbecker_**
> * **@dohrau** (reviewer)
> * **@mschwerhoff**
>
> Source: https://github.com/viperproject/silver/commit/e8a6f4cb8bf52418b3048549173b7f5d756cfa7b on branch `nilsbecker_/silver-sampleprettyprinting/default`
> Destination: https://github.com/viperproject/silver/commit/a384ea0d54848d0cf48c2dc7051a7ec63235e8c7 on branch `master`
>
> State: **`OPEN`**

These will be used by sample to add loop pre-/postconditions and inferred \(potentially unsound\) invariants as comments.
