### PR TITLE
Removed usage of Stream in Termination Plugin

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
@@ -29,17 +29,7 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
     DecreasesSpecification.fromNode(w)
   }
 
-  /**
-   * Transforms all the methods in the (original) program to contain termination checks.
-   */
-  protected def transformMethods(): Unit = {
-    program.methods.foreach(m => {
-      val method = transformMethod(m)
-      methods.update(m.name, method)
-    })
-  }
-
-  private def transformMethod(m: Method): Method = {
+  protected def transformMethod(m: Method): Method = {
     m.body match {
       case Some(body) =>
         val context = MContext(m)
@@ -79,7 +69,7 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
 
       getMethodDecreasesSpecification(context.methodName).tuple match {
         case Some(callerTuple) => // check that called method decreases tuple under the methods tuple condition
-          val calledMethod = methods(mc.methodName)
+          val calledMethod = program.findMethod(mc.methodName)
           val mapFormalArgsToCalledArgs = Map(calledMethod.formalArgs.map(_.localVar).zip(mc.args): _*)
           val calleeDec = getMethodDecreasesSpecification(mc.methodName)
 
@@ -116,9 +106,10 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
     case (mc: MethodCall, ctxt) if ctxt.c.mutuallyRecursiveMeths.contains(program.findMethod(mc.methodName)) =>
       val context = ctxt.c
 
+
       getMethodDecreasesSpecification(context.methodName).tuple match {
         case Some(methodTuple) => // check that called method terminates under the methods tuple condition
-          val calledMethod = methods(mc.methodName)
+          val calledMethod = program.findMethod(mc.methodName)
           val mapFormalArgsToCalledArgs = Map(calledMethod.formalArgs.map(_.localVar).zip(mc.args): _*)
           val decDest = getMethodDecreasesSpecification(mc.methodName)
 
@@ -268,7 +259,7 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
 
     def process(m: Method, n: Node) {
       n visit {
-        case mc@MethodCall(m2name, _, _) =>
+        case MethodCall(m2name, _, _) =>
           graph.addEdge(m, program.findMethod(m2name))
       }
     }

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/ProgramManager.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/ProgramManager.scala
@@ -6,7 +6,7 @@
 
 package viper.silver.plugin.standard.termination.transformation
 
-import viper.silver.ast.{Domain, ExtensionMember, Field, Function, Method, Predicate, Program}
+import viper.silver.ast.Program
 import viper.silver.verifier.AbstractError
 
 import scala.collection.mutable
@@ -20,30 +20,7 @@ trait ProgramManager{
   // original program
   val program: Program
 
-  // maps of all program features including the ones newly created/added
-  protected val domains: mutable.Map[String, Domain] = collection.mutable.ListMap[String, Domain](program.domains.map(d => d.name -> d): _*)
-  protected val fields: mutable.Map[String, Field] = collection.mutable.ListMap[String, Field](program.fields.map(f => f.name -> f): _*)
-  protected val functions: mutable.Map[String, Function] = collection.mutable.ListMap[String, Function](program.functions.map(f => f.name -> f): _*)
-  protected val predicates: mutable.Map[String, Predicate] = collection.mutable.ListMap[String, Predicate](program.predicates.map(f => f.name -> f): _*)
-  protected val methods: mutable.Map[String, Method] = collection.mutable.ListMap[String, Method](program.methods.map(f => f.name -> f): _*)
-  protected val extensions: mutable.Map[String, ExtensionMember] = collection.mutable.ListMap[String, ExtensionMember](program.extensions.map(e => e.name -> e): _*)
-
-  /**
-   * Creates a new program containing all the transformed and newly added features.
-   * @return new program.
-   */
-  final def getNewProgram: Program = {
-    Program(domains.values.toSeq,
-      fields.values.toSeq,
-      functions.values.toSeq,
-      predicates.values.toSeq,
-      methods.values.toSeq,
-      extensions.values.toSeq)(program.pos, program.info, program.errT)
-  }
-
-
   // all names used in the program
-  // including arguments and local vars because they could also cause conflicts.
   private val usedNames: mutable.Set[String] = collection.mutable.Set(program.transitiveScopedDecls.map(_.name): _*)
 
 

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/Trafo.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/Trafo.scala
@@ -10,7 +10,7 @@ import viper.silver.ast._
 import viper.silver.verifier.AbstractError
 
 /**
- * Trafo combines the ProgramManager with
+ * Trafo combines the ProgramManager (which manages name conflicts) with
  * FunctionCheck (which generates termination checks for functions) and
  * MethodCheck (which generates termination checks for methods and whiles)
  * @param program: The program to be extended with termination checks.
@@ -28,13 +28,13 @@ final class Trafo(override val program: Program,
   def getTransformedProgram: Program = {
     transformedProgram.getOrElse({
 
-      // call the function/method termination check transformers
-      transformFunctions()
-      transformMethods()
+      val proofMethods: Seq[Method] = program.functions.flatMap(generateProofMethods)
+      val newMethods: Seq[Method] = program.methods.map(transformMethod)
 
-      // obtain the new program
-      val newProgram = getNewProgram
+      val newProgram: Program = program.copy(methods = newMethods ++ proofMethods)(program.pos,program.info,program.errT)
+
       transformedProgram = Some(newProgram)
+
       newProgram
     })
   }


### PR DESCRIPTION
I refactored the termination plugin, such that the generated Viper program members are not of type Stream (a.k.a. lazy list).