### PR TITLE
Fixed termination check for non-recursive method calls

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
@@ -108,9 +108,9 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
         case None => // no tuple is defined, hence no checks are done.
           (mc, ctxt)
       }
-    case (mc: MethodCall, ctxt) if ctxt.c.mutuallyRecursiveMeths.contains(program.findMethod(mc.methodName)) =>
+    case (mc: MethodCall, ctxt) =>
+      // non-recursive call
       val context = ctxt.c
-
 
       getMethodDecreasesSpecification(context.methodName).tuple match {
         case Some(methodTuple) => // check that called method terminates under the methods tuple condition

--- a/src/test/resources/termination/methods/basic/decCondition.vpr
+++ b/src/test/resources/termination/methods/basic/decCondition.vpr
@@ -1,0 +1,47 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/int.vpr>
+
+method m(x: Int)
+  decreases x if x >= 0
+  decreases _ if x < 0
+{
+  if (x >= 0){
+    if (x != 0){
+      m(x-1)
+    }
+  }else{
+    var y: Int
+    m(y)
+  }
+}
+
+method n(y: Int)
+    decreases
+{
+    m(y)
+}
+
+
+method m_e(x: Int)
+  decreases x if x >= 0
+  // decreases _ if x < 0
+{
+  if (x >= 0){
+    if (x != 0){
+      //:: ExpectedOutput(termination.failed:tuple.condition.false)
+      m_e(x-2) // m(x-1)
+    }
+  }else{
+    var y: Int
+    m_e(y)
+  }
+}
+
+method n_e(y: Int)
+    decreases
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    m_e(y)
+}


### PR DESCRIPTION
There was a bug which caused non-recursive method calls not to be checked for termination.