### PR TITLE
Extended issue 491 test case

### DIFF
--- a/src/test/resources/all/issues/silicon/0491.vpr
+++ b/src/test/resources/all/issues/silicon/0491.vpr
@@ -12,3 +12,30 @@ function foo(l:Ref, i: Int) : Bool
   forall j: Int :: {list2(l,j)} {foo(l.next, j)}
         i == j ==> unfolding list2(l,j) in l.next == null ? true : foo(l.next, j)
 }
+
+method needsPredicateTrigger() {
+  var k : Int
+  var l1 : Ref
+  l1 := new(elem, next)
+  l1.next := null
+
+  fold list2(l1, k)
+
+  /**
+   This yields a proof which does not need the predicate based trigger of foo()'s axiom,
+   because the axiom can be unfolded one level per function application.
+   This just shows that the trigger really is what's missing in the assertion below.
+   **/
+  // assert foo(l1, k)
+
+  var l2 : Ref
+  l2 := new(elem, next)
+  l2.next := l1
+
+  fold list2(l2, k)
+
+  //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/491/)
+  assert foo(l2, k)
+
+}
+


### PR DESCRIPTION
This is intended for [Silicon#491](https://github.com/viperproject/silicon/issues/491), which is currently a green testcase although the underlying problem is not fixed. I am looking into it again and trying to fix it on my fork, so I added some assertions that fail with the current workaround. It is basically the same as https://github.com/viperproject/silver/blob/master/src/test/resources/all/functions/recursive_unrolling.vpr which is a testcase specifically designed to exercise the predicate based function trigger mechanism.