### PR TITLE
Fix performance regression of AST traversal

### DIFF
--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -6,6 +6,7 @@
 
 package viper.silver.ast
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 import pretty.FastPrettyPrinter
 import utility._
@@ -13,8 +14,6 @@ import viper.silver.ast.utility.rewriter.Traverse.Traverse
 import viper.silver.ast.utility.rewriter.{Rewritable, StrategyBuilder, Traverse}
 import viper.silver.verifier.errors.ErrorNode
 import viper.silver.verifier.{AbstractVerificationError, ConsistencyError, ErrorReason}
-
-import scala.collection.mutable
 
 /*
 

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -15,7 +15,6 @@ import viper.silver.verifier.errors.ErrorNode
 import viper.silver.verifier.{AbstractVerificationError, ConsistencyError, ErrorReason}
 
 import scala.collection.mutable
-import scala.language.reflectiveCalls
 
 /*
 
@@ -65,17 +64,9 @@ trait Node extends Iterable[Node] with Rewritable {
   }
 
   override def iterator: Iterator[Node] = {
-    val iterator = new Iterator[Node] {
-      var remaining = mutable.Queue.empty[Node]
-
-      override def hasNext: Boolean = remaining.nonEmpty
-
-      override def next(): Node = remaining.dequeue()
-    }
-
-    Visitor.visit(this, Nodes.subnodes) { case n: Node => iterator.remaining.enqueue(n) }
-
-    iterator
+    val remaining = mutable.Queue.empty[Node]
+    Visitor.visit(this, Nodes.subnodes) { case n: Node => remaining.enqueue(n) }
+    remaining.iterator
   }
 
   /** @see [[Visitor.visit()]] */

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -49,7 +49,7 @@ Some design choices:
   * Note that all but Program are transitive subtypes of `Node` via `Hashable`. The reason is
   * that AST node hashes may depend on the entire program, not just their sub-AST.
   */
-trait Node extends Iterable[Node] with Rewritable {
+trait Node extends Traversable[Node] with Rewritable {
 
   /** @see [[Nodes.subnodes()]] */
   def subnodes = Nodes.subnodes(this)
@@ -62,11 +62,7 @@ trait Node extends Iterable[Node] with Rewritable {
     Visitor.reduceWithContext(this, Nodes.subnodes)(context, enter, combine)
   }
 
-  override def iterator: Iterator[Node] = {
-    val remaining = mutable.Queue.empty[Node]
-    Visitor.visit(this, Nodes.subnodes) { case n: Node => remaining.enqueue(n) }
-    remaining.iterator
-  }
+  override def foreach[A](f: Node => A) = Visitor.visit(this, Nodes.subnodes) { case a: Node => f(a) }
 
   /** @see [[Visitor.visit()]] */
   def visit[A](f: PartialFunction[Node, A]): Unit = {

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -6,7 +6,6 @@
 
 package viper.silver.ast
 
-import scala.collection.mutable
 import scala.reflect.ClassTag
 import pretty.FastPrettyPrinter
 import utility._

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -13,6 +13,8 @@ import viper.silver.ast.utility.rewriter.Traverse.Traverse
 import viper.silver.ast.utility.rewriter.{Rewritable, StrategyBuilder, Traverse}
 import viper.silver.verifier.errors.ErrorNode
 import viper.silver.verifier.{AbstractVerificationError, ConsistencyError, ErrorReason}
+
+import scala.collection.mutable
 import scala.language.reflectiveCalls
 
 /*
@@ -64,18 +66,14 @@ trait Node extends Iterable[Node] with Rewritable {
 
   override def iterator: Iterator[Node] = {
     val iterator = new Iterator[Node] {
-      var remaining = Seq.empty[Node]
+      var remaining = mutable.Queue.empty[Node]
 
       override def hasNext: Boolean = remaining.nonEmpty
 
-      override def next(): Node = {
-        val result = remaining.head
-        remaining = remaining.tail
-        result
-      }
+      override def next(): Node = remaining.dequeue()
     }
 
-    Visitor.visit(this, Nodes.subnodes) { case n: Node => iterator.remaining ++= Seq(n) }
+    Visitor.visit(this, Nodes.subnodes) { case n: Node => iterator.remaining.enqueue(n) }
 
     iterator
   }

--- a/src/main/scala/viper/silver/ast/utility/Traversable.scala
+++ b/src/main/scala/viper/silver/ast/utility/Traversable.scala
@@ -30,8 +30,19 @@ trait Traversable[+A] {
     override def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
   }
 
-  /**
-    * Builds a new collection by applying a partial function to all elements of this collection on which the function
+  /** Finds the first element of the $coll for which the given partial
+    * function is defined, and applies the partial function to it.
+    */
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
+    for (x <- self) {
+      if (pf.isDefinedAt(x)) {
+        return Some(pf(x))
+      }
+    }
+    None
+  }
+
+  /** Builds a new collection by applying a partial function to all elements of this collection on which the function
     * is defined.
     */
   def collect[B](pf: PartialFunction[A, B]): Iterable[B] = {

--- a/src/main/scala/viper/silver/ast/utility/Traversable.scala
+++ b/src/main/scala/viper/silver/ast/utility/Traversable.scala
@@ -19,7 +19,7 @@ trait Traversable[+A] {
   def withFilter(p: A => Boolean): Traversable[A] = new WithFilter(p)
 
   class WithFilter(p: A => Boolean) extends Traversable[A] {
-    /** Applies a function to all filtered element of the outer collection. */
+    /** Applies a function to all filtered elements of the outer collection. */
     def foreach[U](f: A => U): Unit = {
       for (x <- self) {
         if (p(x)) f(x)
@@ -27,10 +27,12 @@ trait Traversable[+A] {
     }
 
     /** Further refines the filter of this collection. */
-    override def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
+    override def withFilter(q: A => Boolean): WithFilter = {
+      new WithFilter(x => p(x) && q(x))
+    }
   }
 
-  /** Finds the first element of the $coll for which the given partial
+  /** Finds the first element of this collection for which the given partial
     * function is defined, and applies the partial function to it.
     */
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
@@ -42,8 +44,8 @@ trait Traversable[+A] {
     None
   }
 
-  /** Builds a new collection by applying a partial function to all elements of this collection on which the function
-    * is defined.
+  /** Builds a new collection by applying a partial function to all elements
+    * of this collection on which the function is defined.
     */
   def collect[B](pf: PartialFunction[A, B]): Iterable[B] = {
     val elements = mutable.Queue.empty[B]

--- a/src/main/scala/viper/silver/ast/utility/Traversable.scala
+++ b/src/main/scala/viper/silver/ast/utility/Traversable.scala
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package viper.silver.ast.utility
+
+import scala.collection.mutable
+
+/** A trait for traversable collections. */
+trait Traversable[+A] {
+  self =>
+
+  /** Applies a function to all element of the collection. */
+  def foreach[B](f: A => B): Unit
+
+  /** Creates a filter of this traversable collection. */
+  def withFilter(p: A => Boolean): Traversable[A] = new WithFilter(p)
+
+  class WithFilter(p: A => Boolean) extends Traversable[A] {
+    /** Applies a function to all filtered element of the outer collection. */
+    def foreach[U](f: A => U): Unit = {
+      for (x <- self) {
+        if (p(x)) f(x)
+      }
+    }
+
+    /** Further refines the filter of this collection. */
+    override def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
+  }
+
+  /**
+    * Builds a new collection by applying a partial function to all elements of this collection on which the function
+    * is defined.
+    */
+  def collect[B](pf: PartialFunction[A, B]): Iterable[B] = {
+    val elements = mutable.Queue.empty[B]
+    for (x <- self) {
+      if (pf.isDefinedAt(x)) {
+        elements.append(pf(x))
+      }
+    }
+    elements
+  }
+}


### PR DESCRIPTION
@mschwerhoff this makes the [program](https://github.com/viperproject/silver/files/5903415/program.vpr.txt) that you sent me verify in 1m 30s.

The remaining slowdown are the allocations performed in the `iterator` method, which put pressure on the GC.

## Update

I added a minimal `Traversable` trait to keep using the old (i.e. before 1df0f34d2be400be42a32a599dad6ecef12f1315) interface and implementation, which does not incur allocation costs.
