### PR TITLE
Fixes Concurrent Execution of Strategies

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
@@ -79,8 +79,6 @@ class SlimViperRegexBuilderWithMatch(regex: Match) {
   */
 object ViperStrategy {
 
-  var forceRewrite: Boolean = false
-
   def SlimRegex(m: Match, p: PartialFunction[Node, Node]) = {
     new SlimViperRegexBuilder &> m |-> p
   }

--- a/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
@@ -5,10 +5,7 @@
 // Copyright (c) 2011-2019 ETH Zurich.
 
 package viper.silver.ast.utility.rewriter
-import viper.silver.ast.Node
-import viper.silver.ast.pretty.FastPrettyPrinter
 import viper.silver.ast.utility.rewriter.Traverse.Traverse
-import viper.silver.parser.PIdnUse
 
 import scala.collection.mutable
 import scala.reflect.runtime.{universe => reflection}

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -607,10 +607,7 @@ object FastParser {
     def replacerOnBody(body: PNode, paramToArgMap: Map[String, PExp], pos: (Position, Position)): PNode = {
 
       // Duplicate the body of the macro to allow for differing type checks depending on the context
-      val oldForce = viper.silver.ast.utility.ViperStrategy.forceRewrite
-      viper.silver.ast.utility.ViperStrategy.forceRewrite = true
       val replicatedBody = body.deepCopyAll
-      viper.silver.ast.utility.ViperStrategy.forceRewrite = oldForce
 
       // Rename locally bound variables in macro's body
       var bodyWithRenamedVars = renamer.execute[PNode](replicatedBody)

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -86,7 +86,7 @@ trait PNode extends Where with Product with Rewritable {
    *
    * @see [[PNode.initProperties()]] */
   def deepCopyAll[A <: PNode]: PNode =
-    StrategyBuilder.Slim[PNode]({case n => n}).forceCopy(_ => true).execute[PNode](this)
+    StrategyBuilder.Slim[PNode]({case n => n}).forceCopy().execute[PNode](this)
 
   private val _children = scala.collection.mutable.ListBuffer[PNode] ()
 

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -86,7 +86,7 @@ trait PNode extends Where with Product with Rewritable {
    *
    * @see [[PNode.initProperties()]] */
   def deepCopyAll[A <: PNode]: PNode =
-    StrategyBuilder.Slim[PNode]({case n => n}).execute[PNode](this)
+    StrategyBuilder.Slim[PNode]({case n => n}).forceCopy({_ => true}).execute[PNode](this)
 
   private val _children = scala.collection.mutable.ListBuffer[PNode] ()
 

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -86,7 +86,7 @@ trait PNode extends Where with Product with Rewritable {
    *
    * @see [[PNode.initProperties()]] */
   def deepCopyAll[A <: PNode]: PNode =
-    StrategyBuilder.Slim[PNode]({case n => n}).forceCopy({_ => true}).execute[PNode](this)
+    StrategyBuilder.Slim[PNode]({case n => n}).forceCopy(_ => true).execute[PNode](this)
 
   private val _children = scala.collection.mutable.ListBuffer[PNode] ()
 


### PR DESCRIPTION
The globally shared `ViperStrategy.forceRewrite` flag causes issues when concurrently executing multiple strategies. In particular, this flag is used during macro expansion to deep-copy particular parts of an AST.
This PR makes the flag strategy-local meaning that different strategies do no longer compete. Calling `.forceCopy(_ => true)` on a strategy restores the old behavior and creates a new instance for each node in the tree even if it does not change.
In addition, `PNode.deepCopyAll` has been adapted to now have the obvious semantic of deep copying the subtree.

Fixes concurrency issues first observed in [ViperServer PR #24](https://github.com/viperproject/viperserver/pull/24).
