### PR TITLE
Add field reporter to trait Verifier

### DIFF
--- a/src/main/scala/viper/silver/frontend/ViperAstProvider.scala
+++ b/src/main/scala/viper/silver/frontend/ViperAstProvider.scala
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2021 ETH Zurich.
+
 package viper.silver.frontend
 
 
@@ -19,7 +25,7 @@ class ViperAstProvider(override val reporter: PluginAwareReporter,
     verify()
   }
 
-  class AstProvidingVerifier extends Verifier {
+  class AstProvidingVerifier(rep: Reporter) extends Verifier {
     private var _config: Config = _
 
     def config: Config = _config
@@ -47,6 +53,8 @@ class ViperAstProvider(override val reporter: PluginAwareReporter,
     override def parseCommandLine(args: Seq[String]): Unit = {
       _config = new Config(args)
     }
+
+    override def reporter: Reporter = rep
   }
 
   // Verification phase omitted
@@ -75,7 +83,7 @@ class ViperAstProvider(override val reporter: PluginAwareReporter,
   protected var instance: AstProvidingVerifier = _
 
   override def createVerifier(fullCmd: String): Verifier = {
-    instance = new AstProvidingVerifier
+    instance = new AstProvidingVerifier(reporter.reporter)
     instance
   }
 

--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -17,7 +17,7 @@ import viper.silver.verifier._
   *
   */
 sealed trait Message {
-  override def toString: String = s"generic_message"
+  override def toString: String = "generic_message"
   val name: String
 }
 
@@ -33,7 +33,7 @@ sealed trait Message {
  * ATG 2020
  */
 sealed trait AstConstructionResultMessage extends Message {
-  override val name: String = s"ast_construction_result"
+  override val name: String = "ast_construction_result"
   def astConstructionTime: Time
 }
 
@@ -52,7 +52,7 @@ case class AstConstructionFailureMessage(astConstructionTime: Time, result: Fail
 }
 
 sealed trait VerificationResultMessage extends Message {
-  override val name: String = s"verification_result"
+  override val name: String = "verification_result"
   def result: VerificationResult
   val verifier: String
 }
@@ -112,9 +112,9 @@ object CachedEntityMessage {
   : VerificationResultMessage =
     result match {
       case Success => 
-        EntitySuccessMessage(verifier, entity, 0, cached = true)
+        EntitySuccessMessage(verifier, entity, 0L.asInstanceOf[Time], cached = true)
       case failure: Failure =>
-        EntityFailureMessage(verifier, entity, 0, failure, cached = true)
+        EntityFailureMessage(verifier, entity, 0L.asInstanceOf[Time], failure, cached = true)
     }
 }
 
@@ -162,23 +162,23 @@ case class StatisticsReport(nOfMethods: Int, nOfFunctions: Int, nOfPredicates: I
                             nOfDomains: Int, nOfFields: Int)
   extends Message {
 
-  override def toString: String = s"statistics_report(" +
+  override lazy val toString: String = s"statistics_report(" +
     s"nom=${nOfMethods.toString}, nofu=${nOfFunctions.toString}, nop=${nOfPredicates.toString}, " +
     s"nod=${nOfDomains.toString}, nofi=${nOfFields.toString})"
 
-  override val name = s"statistics"
+  override val name = "statistics"
 }
 
 case class ProgramOutlineReport(members: List[Entity]) extends Message {
 
-  override def toString: String = s"program_outline_report(members=${members.map(print)})"
-  override val name: String = s"program_outline"
+  override lazy val toString: String = s"program_outline_report(members=${members.map(print)})"
+  override val name: String = "program_outline"
 }
 
 case class ProgramDefinitionsReport(definitions: List[Definition]) extends Message {
 
-  override def toString: String = s"program_definitions_report(definitions=${definitions.toString}"
-  override val name: String = s"program_definitions"
+  override lazy val toString: String = s"program_definitions_report(definitions=${definitions.toString}"
+  override val name: String = "program_definitions"
 }
 
 // TODO: Variable level of detail?
@@ -194,21 +194,21 @@ case class ExecutionTraceReport(memberTraces: Seq[Any],
        |  functionPostAxioms=${functionPostAxioms.toString}
        |)""".stripMargin
 
-  override val name: String = s"symbolic_execution_logger_report"
+  override val name: String = "symbolic_execution_logger_report"
 }
 
 case class ExceptionReport(e: java.lang.Throwable) extends Message {
 
   override def toString: String = s"exception_report(e=${e.toString})"
-  override val name: String = s"exception_report"
+  override val name: String = "exception_report"
 }
 
 case class InvalidArgumentsReport(tool_signature: String, errors: List[AbstractError])
   extends Message {
 
-  override def toString: String =
+  override lazy val toString: String =
     s"invalid_args_report(tool_signature=${tool_signature}, errors=[${errors.mkString(",")}])"
-  override val name: String = s"invalid_args_report"
+  override val name: String = "invalid_args_report"
 }
 
 object BackendSubProcessStages extends Enumeration {
@@ -225,47 +225,47 @@ object BackendSubProcessStages extends Enumeration {
 case class BackendSubProcessReport(tool_signature: String, process_exe: String,
                                    phase: BackendSubProcessStage, pid_maybe: Option[Long] = None) extends Message {
 
-  override def toString: String =
+  override lazy val toString: String =
     s"backend_sub_process_report(tool_signature=${tool_signature}, process_exe=${process_exe}, " +
     s"phase=${phase.toString}, pid=${pid_maybe match {
       case Some(pid) => pid.toString
       case None => "<not provided>"
     }})"
 
-  override val name: String = s"backend_sub_process_report"
+  override val name: String = "backend_sub_process_report"
 }
 
 case class ExternalDependenciesReport(deps: Seq[Dependency]) extends Message {
 
-  override def toString: String = s"external_dependencies_report(deps=[${deps.mkString(",")}])"
-  override val name: String = s"external_dependencies_report"
+  override lazy val toString: String = s"external_dependencies_report(deps=[${deps.mkString(",")}])"
+  override val name: String = "external_dependencies_report"
 }
 
 case class WarningsDuringParsing(warnings: Seq[ParseReport]) extends Message {
-  override def toString: String = s"warnings_during_parsing(warnings=${warnings.toString})"
-  override val name: String = s"warnings_during_parsing"
+  override lazy val toString: String = s"warnings_during_parsing(warnings=${warnings.toString})"
+  override val name: String = "warnings_during_parsing"
 }
 
 case class WarningsDuringTypechecking(warnings: Seq[TypecheckerWarning]) extends Message {
-  override def toString: String = s"warnings_during_typechecking(warnings=${warnings.toString})"
-  override val name: String = s"warnings_during_typechecking"
+  override lazy val toString: String = s"warnings_during_typechecking(warnings=${warnings.toString})"
+  override val name: String = "warnings_during_typechecking"
 }
 
 abstract class SimpleMessage(val text: String) extends Message {
-  override def toString: String = s"$name(text=$text)"
-  override val name: String = s"simple_message"
+  override lazy val toString: String = s"$name(text=$text)"
+  override val name: String = "simple_message"
 }
 
 case class ConfigurationConfirmation(override val text: String) extends SimpleMessage(text) {
-  override val name: String = s"configuration_confirmation"
+  override val name: String = "configuration_confirmation"
 }
 
 case class InternalWarningMessage(override val text: String) extends SimpleMessage(text) {
-  override val name: String = s"internal_warning_message"
+  override val name: String = "internal_warning_message"
 }
 
 case class CopyrightReport(override val text: String) extends SimpleMessage(text) {
-  override val name: String = s"copyright_report"
+  override val name: String = "copyright_report"
 }
 
 case class MissingDependencyReport(override val text: String) extends SimpleMessage(text) {
@@ -275,5 +275,5 @@ case class MissingDependencyReport(override val text: String) extends SimpleMess
 // FIXME: for debug purposes only: a pong message can be reported to indicate
 // FIXME: that the verification backend is alive.
 case class PongMessage(override val text: String) extends SimpleMessage(text) {
-  override val name: String = s"dbg__pong"
+  override val name: String = "dbg__pong"
 }

--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.silver.reporter
 
+import viper.silver.reporter.BackendSubProcessStages.BackendSubProcessStage
 import viper.silver.verifier._
 
 /**
@@ -208,6 +209,30 @@ case class InvalidArgumentsReport(tool_signature: String, errors: List[AbstractE
   override def toString: String =
     s"invalid_args_report(tool_signature=${tool_signature}, errors=[${errors.mkString(",")}])"
   override val name: String = s"invalid_args_report"
+}
+
+object BackendSubProcessStages extends Enumeration {
+  type BackendSubProcessStage = Value
+  val BeforeInputSent         = Value(1, "before_input_sent")
+  val AfterInputSent          = Value(2, "after_input_sent")
+  val onOutput                = Value(3, "on_output")
+  val OnError                 = Value(4, "on_error")
+  val BeforeTermination       = Value(5, "before_termination")
+  val OnExit                  = Value(6, "on_exit")
+  val AfterTermination        = Value(7, "after_termination")
+}
+
+case class BackendSubProcessReport(tool_signature: String, process_exe: String,
+                                   phase: BackendSubProcessStage, pid_maybe: Option[Long] = None) extends Message {
+
+  override def toString: String =
+    s"backend_sub_process_report(tool_signature=${tool_signature}, process_exe=${process_exe}, " +
+    s"phase=${phase.toString}, pid=${pid_maybe match {
+      case Some(pid) => pid.toString
+      case None => "<not provided>"
+    }})"
+
+  override val name: String = s"backend_sub_process_report"
 }
 
 case class ExternalDependenciesReport(deps: Seq[Dependency]) extends Message {

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.silver.reporter
 
@@ -55,7 +55,7 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
         })
       case CopyrightReport(text) =>
       case MissingDependencyReport(text) =>
-
+      case BackendSubProcessReport(_, _, _, _) =>
       case EntitySuccessMessage(verifier, concerning, time, cached) =>
         csv_file.write(s"EntitySuccessMessage,${concerning.name},${time}, ${cached}\n")
       case EntityFailureMessage(verifier, concerning, time, result, cached) =>
@@ -149,6 +149,8 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
 
       case CopyrightReport(text) =>
         println( text )
+
+      case BackendSubProcessReport(_, _, _, _) =>
 
       case MissingDependencyReport(text) =>
         println( s"encountered missing dependency: $text" )

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -53,16 +53,15 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
         errors.foreach(error => {
           csv_file.write(s"WarningsDuringParsing,${error}\n")
         })
-      case CopyrightReport(text) =>
-      case MissingDependencyReport(text) =>
-      case BackendSubProcessReport(_, _, _, _) =>
+
       case EntitySuccessMessage(verifier, concerning, time, cached) =>
         csv_file.write(s"EntitySuccessMessage,${concerning.name},${time}, ${cached}\n")
       case EntityFailureMessage(verifier, concerning, time, result, cached) =>
         csv_file.write(s"EntityFailureMessage,${concerning.name},${time}, ${cached}\n")
-      case ConfigurationConfirmation(_) =>
-      case InternalWarningMessage(_) =>
-      case sm:SimpleMessage =>
+
+      case _: SimpleMessage | _: CopyrightReport | _: MissingDependencyReport | _: BackendSubProcessReport |
+           _: InternalWarningMessage | _: ConfigurationConfirmation=> // Irrelevant for reporting
+
       case _ =>
         println( s"Cannot properly print message of unsupported type: $msg" )
     }
@@ -150,7 +149,7 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
       case CopyrightReport(text) =>
         println( text )
 
-      case BackendSubProcessReport(_, _, _, _) =>
+      case BackendSubProcessReport(_, _, _, _) =>  // Not relevant to the end user
 
       case MissingDependencyReport(text) =>
         println( s"encountered missing dependency: $text" )

--- a/src/main/scala/viper/silver/verifier/Verifier.scala
+++ b/src/main/scala/viper/silver/verifier/Verifier.scala
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.silver.verifier
 
 import viper.silver.ast.Program
 import viper.silver.components.LifetimeComponent
+import viper.silver.reporter.{NoopReporter, Reporter}
 
 /** An abstract class for verifiers of Viper programs.
   *
@@ -91,6 +92,8 @@ trait Verifier extends LifetimeComponent {
     * is unspecified.
     */
   def stop(): Unit
+
+  def reporter: Reporter
 }
 
 /**
@@ -102,6 +105,7 @@ class NoVerifier extends Verifier {
   val buildVersion = ""
   val copyright = ""
   val dependencies = Nil
+  val reporter: Reporter = NoopReporter
 
   def debugInfo(info: Seq[(String, Any)]): Unit = {}
   def parseCommandLine(args: Seq[String]): Unit = {}

--- a/src/test/scala/IOTests.scala
+++ b/src/test/scala/IOTests.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 import java.io.File
 import java.nio.file.Paths
@@ -11,6 +11,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import viper.silver.ast.{NoPosition, Position, Program}
 import viper.silver.frontend.{SilFrontend, SilFrontendConfig}
+import viper.silver.reporter.{Reporter, StdIOReporter}
 import viper.silver.verifier.errors.ErrorNode
 import viper.silver.verifier._
 
@@ -140,7 +141,7 @@ class IOTests extends AnyFunSuite with Matchers {
 
     override def buildVersion: String = "2.72"
 
-    override def copyright: String = "(c) Copyright ETH Zurich 2012 - 2018"
+    override def copyright: String = "(c) Copyright ETH Zurich 2012 - 2021"
 
     override def debugInfo(info: Seq[(String, Any)]): Unit = {}
 
@@ -176,6 +177,8 @@ class IOTests extends AnyFunSuite with Matchers {
     }
 
     override def stop(): Unit = {}
+
+    override def reporter: Reporter = StdIOReporter()
   }
 
   class MockIOConfig(args: Seq[String]) extends SilFrontendConfig(args, "MockIOVerifier") {

--- a/src/test/scala/PluginTests.scala
+++ b/src/test/scala/PluginTests.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 import java.nio.file.Paths
 
@@ -11,6 +11,7 @@ import viper.silver.ast.{LocalVar, Perm, Program}
 import viper.silver.frontend.{SilFrontend, SilFrontendConfig}
 import viper.silver.parser.{PIdnDef, PPredicate, PProgram}
 import viper.silver.plugin.{SilverPlugin, SilverPluginManager}
+import viper.silver.reporter.{Reporter, StdIOReporter}
 import viper.silver.verifier.errors.Internal
 import viper.silver.verifier.reasons.FeatureUnsupported
 import viper.silver.verifier._
@@ -276,7 +277,7 @@ class PluginTests extends AnyFunSuite {
 
     override def buildVersion: String = "2.71"
 
-    override def copyright: String = "(c) Copyright ETH Zurich 2012 - 2018"
+    override def copyright: String = "(c) Copyright ETH Zurich 2012 - 2021"
 
     override def debugInfo(info: Seq[(String, Any)]): Unit = {}
 
@@ -293,6 +294,8 @@ class PluginTests extends AnyFunSuite {
     }
 
     override def stop(): Unit = {}
+
+    override def reporter: Reporter = StdIOReporter()
   }
 
   class MockPluginConfig(args: Seq[String]) extends SilFrontendConfig(args, "MockPluginVerifier"){


### PR DESCRIPTION
While Silicon had already incorporated the reporter mechanism, Carbon instances didn't use reporting at all. However, sometimes it is needed to get information from Carbon in real time — e.g. for the IDE to know at which phase the communication with Boogie is (in case it needs to catch zombie Z3 processes that Boogie may leave behind). 

A more fundamental reason for using reporting is that at some point Carbon should probably implement asynchronous IO, and reporting would be useful for things like progress indication, profiling, etc. 

Generally, it seems reasonable that a Viper verifier should have the ability the report things to the client in real time. The Reporter trait seem to be an ideal solution for when the client expects something slightly more sophisticated than STDOUT or STDERR, but it also supports the former. 

Note that here we want ```Reporter``` as opposed to ```PluginAwareReporter``` as the latter is needed only for Silver plugins; I think that the verifiers don't have to know about the Silver plugin system. 