### PR TITLE
AnnotationParser extending

### DIFF
--- a/src/test/scala/AnnotationBasedTestSuite.scala
+++ b/src/test/scala/AnnotationBasedTestSuite.scala
@@ -29,7 +29,7 @@ abstract class AnnotationBasedTestSuite extends ResourceBasedTestSuite {
    */
   def systemsUnderTest: Seq[SystemUnderTest]
 
-  def buildTestInput(file: Path, prefix: String) =
+  def buildTestInput(file: Path, prefix: String) :AnnotatedTestInput =
     DefaultAnnotatedTestInput(file, prefix)
 
   /** Registers a given test input for a given system under test. */

--- a/src/test/scala/AnnotationBasedTestSuite.scala
+++ b/src/test/scala/AnnotationBasedTestSuite.scala
@@ -176,7 +176,9 @@ case class OutputMatcher(
       case _: IgnoreOthers =>
       case _: MissingOutput =>
         sys.error("MissingOutput should not occur here because they were previously filtered")
-      case c:CustomAnnotation =>sys.error(c.notFoundMsg) // TODO: make this carry more information
+      case c:CustomAnnotation => val corresponding = actualOutputs.find(_.isSameLine(c.file,c.forLineNr)) ;
+                                  if(corresponding.isDefined) {errors ::= TestAdditionalOutputError(corresponding.get) }
+                                    errors ::= c.notFoundError // TODO: make this carry more information
     }
     }
 

--- a/src/test/scala/AnnotationBasedTestSuite.scala
+++ b/src/test/scala/AnnotationBasedTestSuite.scala
@@ -141,12 +141,13 @@ case class OutputMatcher(
           id.matches(actual.fullId) && actual.isSameLine(file, lineNr)
         case IgnoreOthers(file, lineNr, _) =>
           actual.isSameLine(file, lineNr)
+        case c:CustomAnnotation => c.matches(actual)
       }) match {
         case Nil => None
         case l => l.find(o => o.isInstanceOf[MissingOutput]) match // prioritise missing output annotations which match
         {
           case Some(mo) => Some(mo) // this is an error - declared missing, but it happened (the fact that this is a problem is handled in the calling code)
-          case None => l.find(o => o.isInstanceOf[ExpectedOutput] || o.isInstanceOf[UnexpectedOutput]) match {
+          case None => l.find(o => o.isInstanceOf[ExpectedOutput] || o.isInstanceOf[UnexpectedOutput] || o.isInstanceOf[CustomAnnotation]) match {
             case Some(eo) =>
               remainingOutputs = remainingOutputs.diff(Seq(eo)) // note: diff removes exactly one instance
               Some(eo) // this case is OK - we matched an annotation for this output
@@ -175,6 +176,7 @@ case class OutputMatcher(
       case _: IgnoreOthers =>
       case _: MissingOutput =>
         sys.error("MissingOutput should not occur here because they were previously filtered")
+      case c:CustomAnnotation =>sys.error(c.notFoundMsg) // TODO: make this carry more information
     }
     }
 

--- a/src/test/scala/SingleFileSilSuite.scala
+++ b/src/test/scala/SingleFileSilSuite.scala
@@ -24,5 +24,5 @@ trait SingleFileSilSuite extends SilSuite {
   def frontend(verifier: Verifier, input: String): Frontend
 
   override def buildTestInput(file: Path, prefix: String) =
-    super.buildTestInput(file, prefix).copy(files = Seq(file))
+    super.buildTestInput(file, prefix).asInstanceOf[DefaultAnnotatedTestInput].copy(files = Seq(file))
 }

--- a/src/test/scala/TestAnnotationParser.scala
+++ b/src/test/scala/TestAnnotationParser.scala
@@ -101,19 +101,21 @@ trait TestAnnotationParser {
   }
   /** get first found annotation (replaces next function in the parse functions)*/
   private def getAnnotation(annotation:String,file:Path,lineNr:Int):Option[TestAnnotation]={
-      val finders :Seq[Option[TestAnnotation]]= getFinders(annotation,file,lineNr)
+      val finders :Seq[Option[TestAnnotation]]= getFinders() map (_.apply(annotation,file,lineNr))
       val found :Seq[TestAnnotation]= finders collect {case Some(a) => a}
       found.headOption
   }
 
-  /** get all defined annotation parsers intended to be replaced by extending classes */
-  private def getFinders(annotation:String,file:Path,lineNr:Int):Seq[Option[TestAnnotation]]={
-    Seq(isExpectedOutput(annotation,file,lineNr),
-        isUnexpectedOutput(annotation,file,lineNr),
-        isMissingOutput(annotation,file,lineNr),
-        isIgnoreOthers(annotation,file,lineNr),
-        isIgnoreFile(annotation,file,lineNr),
-        isIgnoreFileList(annotation,file,lineNr)
+  /** get all defined annotation parsers intended to be replaced by extending classes 
+   * the order of the entries are the same as the implicit "next field ordering" from before
+  */
+  private def getFinders():Seq[(String,Path,Int)=>Option[TestAnnotation]]={
+    Seq(isExpectedOutput,
+        isUnexpectedOutput,
+        isMissingOutput,
+        isIgnoreOthers,
+        isIgnoreFile,
+        isIgnoreFileList
         )
   }
 

--- a/src/test/scala/TestAnnotationParser.scala
+++ b/src/test/scala/TestAnnotationParser.scala
@@ -109,7 +109,7 @@ trait TestAnnotationParser {
   /** Get all defined annotation parsers; intended to be replaced by extending classes.
    * The order of the entries are the same as the implicit "next field ordering" from before
   */
-  private def getFinders():Seq[(String,Path,Int)=>Option[TestAnnotation]]={
+  def getFinders():Seq[(String,Path,Int)=>Option[TestAnnotation]]={
     Seq(isExpectedOutput,
         isUnexpectedOutput,
         isMissingOutput,

--- a/src/test/scala/TestAnnotationParser.scala
+++ b/src/test/scala/TestAnnotationParser.scala
@@ -99,15 +99,15 @@ trait TestAnnotationParser {
       }
     }
   }
-  /** get first found annotation (replaces next function in the parse functions)*/
+  /** Get first found annotation */
   private def getAnnotation(annotation:String,file:Path,lineNr:Int):Option[TestAnnotation]={
       val finders :Seq[Option[TestAnnotation]]= getFinders() map (_.apply(annotation,file,lineNr))
       val found :Seq[TestAnnotation]= finders collect {case Some(a) => a}
       found.headOption
   }
 
-  /** get all defined annotation parsers intended to be replaced by extending classes 
-   * the order of the entries are the same as the implicit "next field ordering" from before
+  /** Get all defined annotation parsers; intended to be replaced by extending classes.
+   * The order of the entries are the same as the implicit "next field ordering" from before
   */
   private def getFinders():Seq[(String,Path,Int)=>Option[TestAnnotation]]={
     Seq(isExpectedOutput,

--- a/src/test/scala/TestAnnotations.scala
+++ b/src/test/scala/TestAnnotations.scala
@@ -198,5 +198,5 @@ case class IgnoreFileList(
 
 trait CustomAnnotation extends LocatedAnnotation{
   def matches(is:AbstractOutput):Boolean
-  def notFoundMsg : String
+  def notFoundError : TestError
 }

--- a/src/test/scala/TestAnnotations.scala
+++ b/src/test/scala/TestAnnotations.scala
@@ -135,7 +135,7 @@ sealed trait LocatedAnnotation extends TestAnnotation {
  * Test annotations that have a location and an identifier
  * (i.e. describe an output of some sort).
  */
-sealed trait OutputAnnotation extends LocatedAnnotation {
+trait OutputAnnotation extends LocatedAnnotation {
   def id: OutputAnnotationId
 
   def sameSource(other: OutputAnnotation) =

--- a/src/test/scala/TestAnnotations.scala
+++ b/src/test/scala/TestAnnotations.scala
@@ -38,7 +38,7 @@ sealed case class TestAnnotations(
    *   ProjectSpecificAnnotations include a project name, e.g., Silicon,
    *   and this case should return true iff the name of the current
    *   project under testing matches the project name that is part of the
-   *   annotation. This ensures that, e.g., UnexpectedOutput-annotations
+   *   annotation. This ensures that, e.g., Un2-annotations
    *   are only "expected" when the corresponding project is tested.
    *
    *   Having different forks of a project unfortunately complicates the
@@ -135,7 +135,7 @@ sealed trait LocatedAnnotation extends TestAnnotation {
  * Test annotations that have a location and an identifier
  * (i.e. describe an output of some sort).
  */
-trait OutputAnnotation extends LocatedAnnotation {
+sealed trait OutputAnnotation extends LocatedAnnotation {
   def id: OutputAnnotationId
 
   def sameSource(other: OutputAnnotation) =
@@ -195,3 +195,8 @@ case class IgnoreFileList(
     annotationLineNr: Int,
     project: String,
     issueNr: Int) extends ProjectSpecificAnnotation
+
+trait CustomAnnotation extends LocatedAnnotation{
+  def matches(is:AbstractOutput):Boolean
+  def notFoundMsg : String
+}

--- a/src/test/scala/TestErrors.scala
+++ b/src/test/scala/TestErrors.scala
@@ -23,6 +23,7 @@ object TestErrorType extends Enumeration {
   val ExpectedButMissingOutput = Value
   val UnexpectedButMissingOutput = Value
   val MissingButPresentOutputs = Value
+  val Custom = Value
 
   /** The message to be displayed before all errors of the same given type. */
   def message(error: TestErrorType): String = error match {
@@ -43,6 +44,8 @@ object TestErrorType extends Enumeration {
       "The following outputs were specified to be missing erroneously " +
         "(MissingOutput) according to the test annotations, but did occur " +
         "during testing (this might be cause by invalid test annotations)"
+    case Custom =>
+      "User defined message:"
   }
 }
 
@@ -88,4 +91,8 @@ case class TestMissingButPresentOutputError(missingOutput: MissingOutput, output
     extends TestError(TestErrorType.MissingButPresentOutputs) {
 
   def message = output.toString
+}
+
+case class TestCustomError(errorMessage:String) extends TestError(TestErrorType.Custom){
+  def message = errorMessage
 }


### PR DESCRIPTION
With this, one can extend the TestAnnotationParser trait and add new TestAnnotations for their project.

The Parser and Suite still work the same as before, so there should be no dependency issues.