### PR TITLE
Support type information in Viper program definitions

### DIFF
--- a/src/main/scala/viper/silver/reporter/package.scala
+++ b/src/main/scala/viper/silver/reporter/package.scala
@@ -6,8 +6,6 @@
 
 package viper.silver
 
-import viper.silver.ast.Type
-
 package object reporter {
   type Time = Long  // in milliseconds
   type File = java.nio.file.Path
@@ -16,9 +14,9 @@ package object reporter {
   def print(e: Entity): String =  // FIXME: treat the natural delimiters and insert `;` where needed.
     e.toString().replaceAll("""\n""", " ").replaceAll("""\s+""", " ")
 
-  type Position = viper.silver.ast.SourcePosition
-  type Scope = viper.silver.ast.AbstractSourcePosition
-
+  type DefPosition = viper.silver.ast.SourcePosition
+  type DefScope = viper.silver.ast.AbstractSourcePosition
+  type ViperType = viper.silver.ast.Type
 
   sealed trait SymbolKind {
     val name: String
@@ -45,7 +43,7 @@ package object reporter {
     val name = "Predicate"
   }
 
-  case class ViperField(viperType: Type) extends TypedSymbol {
+  case class ViperField(viperType: ViperType) extends TypedSymbol {
     val name = "Field"
   }
 
@@ -53,11 +51,11 @@ package object reporter {
     val name = "Method"
   }
 
-  case class ViperArgument(viperType: Type) extends TypedSymbol {
+  case class ViperArgument(viperType: ViperType) extends TypedSymbol {
     val name = "Argument"
   }
 
-  case class ViperReturnParameter(viperType: Type) extends TypedSymbol {
+  case class ViperReturnParameter(viperType: ViperType) extends TypedSymbol {
     val name = "Return"
   }
 
@@ -66,11 +64,12 @@ package object reporter {
     val name = "Local"
   }
 
-  case class ViperTypedLocalDefinition(viperType: Type) extends TypedSymbol {
+  case class ViperTypedLocalDefinition(viperType: ViperType) extends TypedSymbol {
     // e.g. var x:Int
     val name = "Local"
   }
 
-  case class Definition(name: String, typ: SymbolKind, location: Position,
-                        scope: Option[Scope] = None)
+  // TODO: discuss if "Declaration" is a better term than e.g. "Definition"
+  case class Definition(name: String, typ: SymbolKind, location: DefPosition,
+                        scope: Option[DefScope] = None)
 }

--- a/src/main/scala/viper/silver/reporter/package.scala
+++ b/src/main/scala/viper/silver/reporter/package.scala
@@ -15,9 +15,9 @@ package object reporter {
   type Entity = viper.silver.ast.Member with Serializable
   def print(e: Entity): String =  // FIXME: treat the natural delimiters and insert `;` where needed.
     e.toString().replaceAll("""\n""", " ").replaceAll("""\s+""", " ")
-
+  
   type Position = viper.silver.ast.SourcePosition
-
+  type Scope = viper.silver.ast.AbstractSourcePosition
 
   trait SymbolType {
     val name: String
@@ -68,6 +68,6 @@ package object reporter {
     val name = "Local"
   }
 
-  case class Definition(name: String, typ: SymbolType, location: viper.silver.ast.Position,
-                        scope: Option[viper.silver.ast.AbstractSourcePosition] = None)
+  case class Definition(name: String, typ: SymbolType, location: Position,
+                        scope: Option[Scope] = None)
 }

--- a/src/main/scala/viper/silver/reporter/package.scala
+++ b/src/main/scala/viper/silver/reporter/package.scala
@@ -23,7 +23,7 @@ package object reporter {
   }
 
   sealed trait TypedSymbol extends SymbolKind {
-    val viperType: Type
+    val viperType: ViperType
   }
 
   // The following case classes are essentially named tuple wrappers.

--- a/src/main/scala/viper/silver/reporter/package.scala
+++ b/src/main/scala/viper/silver/reporter/package.scala
@@ -15,32 +15,33 @@ package object reporter {
   type Entity = viper.silver.ast.Member with Serializable
   def print(e: Entity): String =  // FIXME: treat the natural delimiters and insert `;` where needed.
     e.toString().replaceAll("""\n""", " ").replaceAll("""\s+""", " ")
-  
+
   type Position = viper.silver.ast.SourcePosition
   type Scope = viper.silver.ast.AbstractSourcePosition
 
-  trait SymbolType {
+
+  sealed trait SymbolKind {
     val name: String
   }
 
-  trait TypedSymbol extends SymbolType {
+  sealed trait TypedSymbol extends SymbolKind {
     val viperType: Type
   }
 
   // The following case classes are essentially named tuple wrappers.
-  case object ViperDomain extends SymbolType {
+  case object ViperDomain extends SymbolKind {
     val name = "Domain"
   }
 
-  case object ViperAxiom extends SymbolType {
+  case object ViperAxiom extends SymbolKind {
     val name = "Axiom"
   }
 
-  case object ViperFunction extends SymbolType {
+  case object ViperFunction extends SymbolKind {
     val name = "Function"
   }
 
-  case object ViperPredicate extends SymbolType {
+  case object ViperPredicate extends SymbolKind {
     val name = "Predicate"
   }
 
@@ -48,7 +49,7 @@ package object reporter {
     val name = "Field"
   }
 
-  case object ViperMethod extends SymbolType {
+  case object ViperMethod extends SymbolKind {
     val name = "Method"
   }
 
@@ -60,14 +61,16 @@ package object reporter {
     val name = "Return"
   }
 
-  case object ViperUntypedLocalDefinition extends SymbolType {
+  case object ViperUntypedLocalDefinition extends SymbolKind {
+    // e.g. a label
     val name = "Local"
   }
 
   case class ViperTypedLocalDefinition(viperType: Type) extends TypedSymbol {
+    // e.g. var x:Int
     val name = "Local"
   }
 
-  case class Definition(name: String, typ: SymbolType, location: Position,
+  case class Definition(name: String, typ: SymbolKind, location: Position,
                         scope: Option[Scope] = None)
 }

--- a/src/main/scala/viper/silver/reporter/package.scala
+++ b/src/main/scala/viper/silver/reporter/package.scala
@@ -6,6 +6,8 @@
 
 package viper.silver
 
+import viper.silver.ast.Type
+
 package object reporter {
   type Time = Long  // in milliseconds
   type File = java.nio.file.Path
@@ -16,7 +18,56 @@ package object reporter {
 
   type Position = viper.silver.ast.SourcePosition
 
+
+  trait SymbolType {
+    val name: String
+  }
+
+  trait TypedSymbol extends SymbolType {
+    val viperType: Type
+  }
+
   // The following case classes are essentially named tuple wrappers.
-  case class Definition(name: String, typ: String, location: viper.silver.ast.Position,
+  case object ViperDomain extends SymbolType {
+    val name = "Domain"
+  }
+
+  case object ViperAxiom extends SymbolType {
+    val name = "Axiom"
+  }
+
+  case object ViperFunction extends SymbolType {
+    val name = "Function"
+  }
+
+  case object ViperPredicate extends SymbolType {
+    val name = "Predicate"
+  }
+
+  case class ViperField(viperType: Type) extends TypedSymbol {
+    val name = "Field"
+  }
+
+  case object ViperMethod extends SymbolType {
+    val name = "Method"
+  }
+
+  case class ViperArgument(viperType: Type) extends TypedSymbol {
+    val name = "Argument"
+  }
+
+  case class ViperReturnParameter(viperType: Type) extends TypedSymbol {
+    val name = "Return"
+  }
+
+  case object ViperUntypedLocalDefinition extends SymbolType {
+    val name = "Local"
+  }
+
+  case class ViperTypedLocalDefinition(viperType: Type) extends TypedSymbol {
+    val name = "Local"
+  }
+
+  case class Definition(name: String, typ: SymbolType, location: viper.silver.ast.Position,
                         scope: Option[viper.silver.ast.AbstractSourcePosition] = None)
 }


### PR DESCRIPTION
IDEs and debuggers can benefit from typed information about program definitions, e.g. local variables. However, we did not report the definitions' types before. This PR adds ```trait SymbolType``` instances of which are now field of ```Definition```s, which are reported to the IDE. 