### PR TITLE
Support incomplete function interpretations in partial SMT models in ModelParser

### DIFF
--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -16,13 +16,13 @@ object ModelParser {
 
   def mapping[_: P]: P[MapEntry] = P("{" ~/ mappingContent ~ "}")
 
-  def mappingContent[_: P]: P[MapEntry] = P(options | partialOptions | default)
+  def mappingContent[_: P]: P[MapEntry] = P(partialOptions | options | default)
 
   def options[_: P]: P[MapEntry] = P(option.rep ~ "else" ~ "->" ~ value).map {
     case (options, default) => MapEntry(options.toMap, default)
   }
 
-  def partialOptions[_: P]: P[MapEntry] = P(option.rep).map(options =>
+  def partialOptions[_: P]: P[MapEntry] = P(option.rep(1)).map(options =>
     MapEntry(options.toMap, UnspecifiedEntry))
 
   def option[_: P]: P[(Seq[ValueEntry], ValueEntry)] = P(value.rep(1) ~ "->" ~/ value)
@@ -30,11 +30,13 @@ object ModelParser {
   def default[_: P]: P[MapEntry] = P(value)
     .map { default => MapEntry(Map.empty, default).resolveFunctionDefinition }
 
-  def value[_: P]: P[ValueEntry] = P(let | constant | application)
+  def value[_: P]: P[ValueEntry] = P(unspecified | let | constant | application)
 
   def let[_: P]: P[ValueEntry] = {
     def substitute(entry: ValueEntry, binding: (String, ValueEntry)): ValueEntry =
       entry match {
+        case UnspecifiedEntry =>
+          UnspecifiedEntry
         case ConstantEntry(value) =>
           binding match {
             case (`value`, replacement) => replacement
@@ -54,6 +56,8 @@ object ModelParser {
   }
 
   def binding[_: P]: P[(String, ValueEntry)] = P("(" ~ idnuse ~ value ~ ")")
+
+  def unspecified[_: P]: P[ValueEntry] = P("(#unspecified)").map(_ => UnspecifiedEntry)
 
   def constant[_: P]: P[ConstantEntry] = P(idnuse).map(ConstantEntry)
 

--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -1,7 +1,5 @@
 package viper.silver.verifier
 
-import java.util.regex.{Matcher, Pattern}
-import scala.collection.mutable
 import fastparse._
 import viper.silver.parser.FastParser.whitespace
 
@@ -18,11 +16,14 @@ object ModelParser {
 
   def mapping[_: P]: P[MapEntry] = P("{" ~/ mappingContent ~ "}")
 
-  def mappingContent[_: P]: P[MapEntry] = P(options | default)
+  def mappingContent[_: P]: P[MapEntry] = P(options | partialOptions | default)
 
   def options[_: P]: P[MapEntry] = P(option.rep ~ "else" ~ "->" ~ value).map {
     case (options, default) => MapEntry(options.toMap, default)
   }
+
+  def partialOptions[_: P]: P[MapEntry] = P(option.rep).map(options =>
+    MapEntry(options.toMap, UnspecifiedEntry))
 
   def option[_: P]: P[(Seq[ValueEntry], ValueEntry)] = P(value.rep(1) ~ "->" ~/ value)
 

--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -16,16 +16,13 @@ object ModelParser {
 
   def mapping[_: P]: P[MapEntry] = P("{" ~/ mappingContent ~ "}")
 
-  def mappingContent[_: P]: P[MapEntry] = P(partialOptions | options | default)
+  def mappingContent[_: P]: P[MapEntry] = P(options | default)
 
-  def options[_: P]: P[MapEntry] = P(option.rep ~ "else" ~ "->" ~ value).map {
-    case (options, default) => MapEntry(options.toMap, default)
+  def options[_: P]: P[MapEntry] = P(option.rep ~ ("else" ~ "->" ~ value).?).map {
+    case (options, default) => MapEntry(options.toMap, default.getOrElse(UnspecifiedEntry))
   }
 
-  def partialOptions[_: P]: P[MapEntry] = P(option.rep(1)).map(options =>
-    MapEntry(options.toMap, UnspecifiedEntry))
-
-  def option[_: P]: P[(Seq[ValueEntry], ValueEntry)] = P(value.rep(1) ~ "->" ~/ value)
+  def option[_: P]: P[(Seq[ValueEntry], ValueEntry)] = P(value.rep(1) ~ "->" ~ value)
 
   def default[_: P]: P[MapEntry] = P(value)
     .map { default => MapEntry(Map.empty, default).resolveFunctionDefinition }

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -23,6 +23,10 @@ sealed trait ModelEntry
 
 sealed trait ValueEntry extends ModelEntry
 
+case object UnspecifiedEntry extends ValueEntry {
+  override def toString: String = "#unspecified"
+}
+
 case class ConstantEntry(value: String) extends ValueEntry {
   override def toString: String = value
 }
@@ -134,7 +138,7 @@ object CounterexampleTransformer {
 
 object Model {
   def apply(modelString: String) : Model = {
-    fastparse.parse(modelString, ModelParser.model(_)) match{
+    fastparse.parse(modelString, ModelParser.model(_)) match {
       case Parsed.Success(model, _) => model
       case failure: Parsed.Failure => throw new Exception(failure.toString)
     }


### PR DESCRIPTION
This PR adds one rule to the ModelParser that supports e.g. the following partial model: 
```
[2] -> {
  T@U!val!9 T@U!val!3 -> false
  T@U!val!9 T@U!val!8 -> true
}
```
This interpretation of the ```[2]``` function does not have an ```else``` case, so it can be parsed as unspecified. Note that Z3 sometimes produces an explicitly unspecified ```else```-cases, e.g.:

```
Set#UnionOne -> {
  else -> (#unspecified)
}
```

However, these used to work already. 


**Usage:** to get partial SMT models through Viper, use e.g. the following command: 
```
java -cp carbon.jar viper.carbon.Carbon --boogieOpt "/p:O:model.partial=false" --counterexample native example.vpr
```

Before this PR, this used to cause a stack trace: 
```
Exception in thread "main" java.lang.Exception: Parsed.Failure(Position 36:1, found "}\n[3] -> {")
        at viper.silver.verifier.Model$.apply(VerificationError.scala:139)
        at viper.carbon.verifier.BoogieInterface.$anonfun$invokeBoogie$2(BoogieInterface.scala:100)
        at viper.carbon.verifier.BoogieInterface.$anonfun$invokeBoogie$2$adapted(BoogieInterface.scala:96)
        at scala.collection.immutable.Range.map(Range.scala:59)
        at viper.carbon.verifier.BoogieInterface.invokeBoogie(BoogieInterface.scala:96)
        at viper.carbon.verifier.BoogieInterface.invokeBoogie$(BoogieInterface.scala:80)
        at viper.carbon.CarbonVerifier.invokeBoogie(CarbonVerifier.scala:25)
        at viper.carbon.CarbonVerifier.verify(CarbonVerifier.scala:196)
        at viper.silver.frontend.DefaultFrontend.verification(Frontend.scala:267)
...
```

This PR fixes the issue. 