### PR TITLE
Customizing Annotation-base Test Suite

### DIFF
--- a/src/test/scala/TestAnnotationParser.scala
+++ b/src/test/scala/TestAnnotationParser.scala
@@ -78,7 +78,7 @@ trait TestAnnotationParser {
           // there should be a space -> report error
           parseErrors ::= TestAnnotationParseError(l, file, curLineNr)
         }
-      } else if (l.startsWith(commentStart)) {
+      } else if (isCommentStart(l)) {
         // ignore comments
       } else {
         // finish parsing annotations
@@ -90,6 +90,16 @@ trait TestAnnotationParser {
       }
     }
     (parseErrors.reverse, finalAnnotations.reverse)
+  }
+
+  /**
+    * Decides whether a line should be ignored because it is a line comment.
+    * By default, all lines starting with `commentStart` are ignored.
+    * However, subclasses can override this function to e.g. differentiate between regular comments and specification
+    * occurring in comments
+    */
+  protected def isCommentStart(trimmedLine: String): Boolean = {
+    trimmedLine.startsWith(commentStart)
   }
 
   /** At the time we parse a test annotation, we cannot know the `forLineNr` yet, so add it correctly now. */


### PR DESCRIPTION
This PR enables clients to specify what a line containing a comment looks like. So far, only a particular prefix could have been specified. However in the case of Gobra, we would like to treat lines starting with `//@` as lines containing specification meaning that they should not be ignored. Lines only starting with `//` should however still be ignored. 