### PR TITLE
Fix pretty-printing of Seqn's comments

### DIFF
--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -374,7 +374,7 @@ trait FastPrettyPrinterBase extends PrettyPrintPrimitives {
       dl <> space <> dr
 
     def <@> (dr: Cont) : Cont =
-      if (dl == nil) dr else dl <> line <> dr
+      if (dl == nil) dr else if (dr == nil) dl else dl <> line <> dr
   }
 
   def line: Cont = line(" ")

--- a/src/test/scala/PrettyPrinterTest.scala
+++ b/src/test/scala/PrettyPrinterTest.scala
@@ -10,7 +10,7 @@ import viper.silver.ast._
 import viper.silver.ast.pretty.FastPrettyPrinter
 
 class PrettyPrinterTest extends AnyFunSuite with Matchers {
-  test("The comment of nested Seqn-s is always printed") {
+  test("The comment of nested Seqn-s is printed correctly") {
     val comment = "Comment XYZ"
     val a = Seqn(Seq(), Seq())(NoPosition, SimpleInfo(Seq(comment)))
     val b = Seqn(Seq(a), Seq())(NoPosition, NoInfo)
@@ -18,6 +18,7 @@ class PrettyPrinterTest extends AnyFunSuite with Matchers {
 
     val printed = FastPrettyPrinter.pretty(c)
 
-    assert(printed.contains(comment))
+    // In particular, we don't want `printed` to end with a newline.
+    assert(printed == "// " + comment)
   }
 }


### PR DESCRIPTION
The pretty-printing of an empty `Seqn` with a comment had an annoying trailing newline character. This PR avoids that.