### PR TITLE
Unroll first and last iteration in encoding

### DIFF
--- a/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
+++ b/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
@@ -185,17 +185,22 @@ object CfgGenerator {
         // check whether the loop is tagged with an id
         val loopId = stmt.info.getUniqueInfo[IdInfo].map(_.id)
         // create labels
+        val thnTarget = TmpLabel.generate("then")
         val headTarget = TmpLabel.generate("head")
         val loopTarget = TmpLabel.generate("loop")
         val afterTarget = TmpLabel.generate("after")
+        // unroll first iter
+        addStatement(ConditionalJumpStmt(cond, thnTarget, afterTarget))
+        addLabel(thnTarget)
         // process loop head
         addLabel(headTarget, addEmptyStmt = false)
         addStatement(LoopHeadStmt(invs, afterTarget, loopId))
-        addStatement(ConditionalJumpStmt(cond, loopTarget, afterTarget))
+        addStatement(JumpStmt(loopTarget))
         // process loop body
         addLabel(loopTarget)
+        addStatement(WrappedStmt(Inhale(cond)()))
         run(body)
-        addStatement(JumpStmt(headTarget))
+        addStatement(ConditionalJumpStmt(cond, headTarget, afterTarget))
         // set label after loop
         addLabel(afterTarget)
       case Seqn(ss, scopedDecls) =>

--- a/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
+++ b/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
@@ -190,7 +190,7 @@ object CfgGenerator {
         val loopTarget = TmpLabel.generate("loop")
         val afterTarget = TmpLabel.generate("after")
         // unroll first iter
-        addStatement(ConditionalJumpStmt(cond, thnTarget, afterTarget))
+        addStatement(ConditionalJumpStmt(Not(cond)(), afterTarget, thnTarget))
         addLabel(thnTarget)
         // process loop head
         addLabel(headTarget, addEmptyStmt = false)


### PR DESCRIPTION
For a
```boogie
while(cond)
 invariant invs
{
  body
}
```
loops we can instead generate the CFG of essentially
```boogie
if(cond) {
  do
   invariant invs
  {
    inhale cond
    body
  } while(cond)
}
```
This essentially unrolls the first and last loop iteration when executed in Silicon.
This change should be identical to https://github.com/viperproject/carbon/pull/399 ⁠— i.e. we should add a flag for enabling this behavior.

The one thing I'm not sure about is the hardcoded `Inhale(cond)`, sometimes we might want this to be an `Assume`? Is there any significant difference?