### PR TITLE
Add info to termination proof methods

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -65,7 +65,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
         if (proofMethodBody != EmptyStmt) {
 
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, f.pres, Nil,
-            Option(Seqn(Seq(proofMethodBody), Nil)()))()
+            Option(Seqn(Seq(proofMethodBody), Nil)()))(info=f.info)
 
           Seq(proofMethod)
         } else {
@@ -99,7 +99,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, f.pres, Nil,
-            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable))()))()
+            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable))()))(info=f.info)
 
           Seq(proofMethod)
         } else {
@@ -118,7 +118,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, Nil, Nil,
-            Option(Seqn(Seq(proofMethodBody), Seq(context.conditionInEx.get))()))()
+            Option(Seqn(Seq(proofMethodBody), Seq(context.conditionInEx.get))()))(info=f.info)
 
           Seq(proofMethod)
         } else {

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -65,7 +65,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
         if (proofMethodBody != EmptyStmt) {
 
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, f.pres, Nil,
-            Option(Seqn(Seq(proofMethodBody), Nil)()))(info=f.info)
+            Option(Seqn(Seq(proofMethodBody), Nil)()))(info = f.info)
 
           Seq(proofMethod)
         } else {
@@ -99,7 +99,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, f.pres, Nil,
-            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable))()))(info=f.info)
+            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable))()))(info = f.info)
 
           Seq(proofMethod)
         } else {
@@ -118,7 +118,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, Nil, Nil,
-            Option(Seqn(Seq(proofMethodBody), Seq(context.conditionInEx.get))()))(info=f.info)
+            Option(Seqn(Seq(proofMethodBody), Seq(context.conditionInEx.get))()))(info = f.info)
 
           Seq(proofMethod)
         } else {


### PR DESCRIPTION
Adds the info of a function to termination proofs generated for said function. This helps a frontend to associate `EntitySuccessMessage` or `EntityFailureMessage`, sent for the termination proof, with the correct node.