### PR TITLE
Use `exp.pos` as error highlighting

### DIFF
--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -338,6 +338,7 @@ object errors {
     val id = "exhale.failed"
     val text = "Exhale might fail."
 
+    override def pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = ExhaleFailed(offendingNode.asInstanceOf[Exhale], this.reason, this.cached)
     def withReason(r: ErrorReason) = ExhaleFailed(offendingNode, r, cached)
   }
@@ -349,6 +350,7 @@ object errors {
     val id = "inhale.failed"
     val text = "Inhale might fail."
 
+    override def pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = InhaleFailed(offendingNode.asInstanceOf[Inhale], this.reason, this.cached)
     def withReason(r: ErrorReason) = InhaleFailed(offendingNode, r, cached)
   }
@@ -382,6 +384,7 @@ object errors {
     val id = "assert.failed"
     val text = "Assert might fail."
 
+    override def pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = AssertFailed(offendingNode.asInstanceOf[Assert], this.reason, this.cached)
     def withReason(r: ErrorReason) = AssertFailed(offendingNode, r, cached)
   }


### PR DESCRIPTION
Non-disruptive change to make `assert`/`exhale`/`inhale` error highlighting more in line with `requires`/`ensures` highlighting. Implements Option 2. from #559