### PR TITLE
amaissen/adjust-plugin-infrastructure

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -6,7 +6,7 @@
 
 package viper.silver.ast
 
-import viper.silver.ast.pretty.{Fixity, Infix, LeftAssociative, NonAssociative, Prefix, RightAssociative}
+import viper.silver.ast.pretty.{Fixity, Infix, LeftAssociative, NonAssociative, Prefix, PrettyPrintPrimitives, RightAssociative}
 import utility.{Consistency, DomainInstances, Nodes, Types, Visitor}
 import viper.silver.ast.MagicWandStructure.MagicWandStructure
 import viper.silver.ast.utility.rewriter.StrategyBuilder
@@ -779,4 +779,5 @@ case class BackendFunc(name: String, smtName: String, override val typ: Type, ov
   */
 trait ExtensionMember extends Member{
   def extensionSubnodes: Seq[Node]
+  def prettyPrint: PrettyPrintPrimitives#Cont
 }

--- a/src/main/scala/viper/silver/ast/Type.scala
+++ b/src/main/scala/viper/silver/ast/Type.scala
@@ -7,6 +7,7 @@
 package viper.silver.ast
 
 import utility.Types
+import viper.silver.ast.pretty.PrettyPrintPrimitives
 import viper.silver.verifier.ConsistencyError
 
 /** Silver types. */
@@ -203,4 +204,5 @@ case class BackendType(boogieName: String, smtName: String) extends AtomicType
 
 trait ExtensionType extends Type{
   def getAstType: Type = ???
+  def prettyPrint: PrettyPrintPrimitives#Cont = ???
 }

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -490,9 +490,9 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
 
   /** Show a program. */
   def showProgram(p: Program): Cont = {
-    val Program(domains, fields, functions, predicates, methods, _) = p
+    val Program(domains, fields, functions, predicates, methods, extensions) = p
     showComment(p) <@>
-      ssep((domains ++ fields ++ functions ++ predicates ++ methods) map show, line <> line)
+      ssep((domains ++ fields ++ functions ++ predicates ++ methods ++ extensions) map show, line <> line)
   }
 
   /** Show a domain member. */
@@ -564,7 +564,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
           })
       case d: Domain =>
         showDomain(d)
-      case _:ExtensionMember => nil
+      case e:ExtensionMember => e.prettyPrint
     }
     showComment(m) <@> memberDoc
   }
@@ -627,6 +627,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
         text(domainName) <> (if (typArgs.isEmpty) nil else brackets(ssep(typArgs, char (',') <> space)))
       case BackendType(boogieName, _) if boogieName != null => boogieName
       case BackendType(_, smtName) => smtName
+      case et: ExtensionType => et.prettyPrint
     }
   }
 

--- a/src/main/scala/viper/silver/parser/Translator.scala
+++ b/src/main/scala/viper/silver/parser/Translator.scala
@@ -31,9 +31,11 @@ case class Translator(program: PProgram) {
 
     program match {
       case PProgram(_, _, pdomains, pfields, pfunctions, ppredicates, pmethods, pextensions, _) =>
-        (pdomains ++ pfields ++ pfunctions ++ ppredicates ++
-            pmethods ++ (pdomains flatMap (_.funcs))) foreach translateMemberSignature
+        pdomains foreach translateMemberSignature
         pextensions foreach translateMemberSignature
+
+        pdomains flatMap (_.funcs) foreach translateMemberSignature
+        (pfields ++ pfunctions ++ ppredicates ++ pmethods) foreach translateMemberSignature
 
         val extensions = pextensions map translate
         val domain = (pdomains map translate) ++ extensions filter (t => t.isInstanceOf[Domain])

--- a/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
@@ -125,6 +125,7 @@ trait ParserPluginTemplate {
     override def name: String = ???
     override def errT: ErrorTrafo = ???
     override def info: Info = ???
+    override def prettyPrint: PrettyPrintPrimitives#Cont = ???
   }
 
   /**


### PR DESCRIPTION
This PR enhances the plugin infrastructure by

1. Allowing pretty printing for ExtensionMember and ExtensionType
2. Changing the order of signature translations (see comments in ea38541ee0c087a2fee8c585c1127734f4323197)