### PR TITLE
WIP: Adjust tests to conform to the parser change in commit aeaebeaef7bf977c

### DIFF
--- a/src/test/resources/all/issues/silicon/0336b.vpr
+++ b/src/test/resources/all/issues/silicon/0336b.vpr
@@ -19,8 +19,8 @@ method bad(b:Set[Ref],l:Ref)
 {
   unfold uf_bank(b);
   fold uf_bank(b);
-  //:: ExpectedOutput(assert.failed:assertion.false)
   assert
+  //:: ExpectedOutput(assert.failed:assertion.false)
     let n == (unfolding uf_bank(b) in l.rank) in
     n > n
 }

--- a/src/test/resources/all/issues/silicon/0370.vpr
+++ b/src/test/resources/all/issues/silicon/0370.vpr
@@ -38,8 +38,8 @@ method barrier_check_2_essence(diz: Ref, current_thread_id: Int, output: VCTOpti
       0 <= k && k < |getVCTOption1(output)| ==>
         acc(getVCTOption1(output)[k].Integer__item, wildcard)
 
-  //:: ExpectedOutput(exhale.failed:assertion.false)
   exhale
+  //:: ExpectedOutput(exhale.failed:assertion.false)
     forall tid: Int, j: Int ::
       (0 <= tid && tid < |getVCTOption1(output)| &&
        0 <= j   &&   j < |getVCTOption1(output)|) ==>

--- a/src/test/resources/all/issues/silicon/0385.vpr
+++ b/src/test/resources/all/issues/silicon/0385.vpr
@@ -52,8 +52,8 @@ method testB(s: Ref, r: Ref)
   requires acc(s.flag)
   requires r.flag
 {
-  //:: ExpectedOutput(assert.failed:assertion.false)
   assert
+  //:: ExpectedOutput(assert.failed:assertion.false)
     foo_1_1(s, r) ||
     foo_1_2(s, r) ||
     foo_2_1(s, r) ||

--- a/src/test/resources/all/issues/silver/0204.vpr
+++ b/src/test/resources/all/issues/silver/0204.vpr
@@ -49,8 +49,8 @@ method test5() {
         (forall x: Int, y: Int :: f2(x, y) ==> (forall z: Int :: f3(x, y, z)))
     --* (forall q: Int :: f1(q))
 
-  //:: ExpectedOutput(exhale.failed:wand.not.found)
   exhale
+  //:: ExpectedOutput(exhale.failed:wand.not.found)
         (forall x: Int, y: Int :: f2(y, x) ==> (forall z: Int :: f3(x, y, z)))
     --* (forall q: Int :: f1(q))
 }


### PR DESCRIPTION
The parser change in commit aeaebeaef7bf977c results in different line numbers being reported for some errors. This PR adjusts the test annotations that are affected (currently the CI for Silicon and Carbon are failing due to this issue).

It is not clear whether we should merge in this PR or whether we should adjust the parser to have the previous behaviour. 

In the new behaviour, if there is, for example, an `assert ...` statement, then the first line seems to be reported where the actual assertion appears. For example 
```
line 1: assert
line 2:          x > 0
```

will lead to line 2 being reported (previously line 1 was reported), while 

```
line 1: assert x > 0
```

will still lead to line 1 being reported
