### PR TITLE
Fix issue in rewriting strategy

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
@@ -400,7 +400,27 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
       node match {
         case map: Map[_, _] => map.map(rewriteTopDown(_, context)).asInstanceOf[A]
 
-        case (t1, t2) => (rewriteTopDown(t1, context), rewriteTopDown(t2, context)).asInstanceOf[A]
+        case (t1, t2) => (
+          rewriteTopDown(t1, context),
+          rewriteTopDown(t2, context)).asInstanceOf[A]
+
+        case (t1, t2, t3) => (
+          rewriteTopDown(t1, context),
+          rewriteTopDown(t2, context),
+          rewriteTopDown(t3, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4) => (
+          rewriteTopDown(t1, context),
+          rewriteTopDown(t2, context),
+          rewriteTopDown(t3, context),
+          rewriteTopDown(t4, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4, t5) => (
+          rewriteTopDown(t1, context),
+          rewriteTopDown(t2, context),
+          rewriteTopDown(t3, context),
+          rewriteTopDown(t4, context),
+          rewriteTopDown(t5, context)).asInstanceOf[A]
 
         case Some(value) => Some(rewriteTopDown(value, context)).asInstanceOf[A]
 
@@ -433,7 +453,27 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
       node match {
         case map: Map[_, _] => map.map(rewriteBottomUp(_, context)).asInstanceOf[A]
 
-        case (t1, t2) => (rewriteBottomUp(t1, context), rewriteBottomUp(t2, context)).asInstanceOf[A]
+        case (t1, t2) => (
+          rewriteBottomUp(t1, context),
+          rewriteBottomUp(t2, context)).asInstanceOf[A]
+
+        case (t1, t2, t3) => (
+          rewriteBottomUp(t1, context),
+          rewriteBottomUp(t2, context),
+          rewriteBottomUp(t3, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4) => (
+          rewriteBottomUp(t1, context),
+          rewriteBottomUp(t2, context),
+          rewriteBottomUp(t3, context),
+          rewriteBottomUp(t4, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4, t5) => (
+          rewriteBottomUp(t1, context),
+          rewriteBottomUp(t2, context),
+          rewriteBottomUp(t3, context),
+          rewriteBottomUp(t4, context),
+          rewriteBottomUp(t5, context)).asInstanceOf[A]
 
         case Some(value) => Some(rewriteBottomUp(value, context)).asInstanceOf[A]
 
@@ -464,7 +504,27 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
       node match {
         case map: Map[_, _] => map.map(rewriteInnermost(_, context)).asInstanceOf[A]
 
-        case (t1, t2) => (rewriteInnermost(t1, context), rewriteInnermost(t2, context)).asInstanceOf[A]
+        case (t1, t2) => (
+          rewriteInnermost(t1, context),
+          rewriteInnermost(t2, context)).asInstanceOf[A]
+
+        case (t1, t2, t3) => (
+          rewriteInnermost(t1, context),
+          rewriteInnermost(t2, context),
+          rewriteInnermost(t3, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4) => (
+          rewriteInnermost(t1, context),
+          rewriteInnermost(t2, context),
+          rewriteInnermost(t3, context),
+          rewriteInnermost(t4, context)).asInstanceOf[A]
+
+        case (t1, t2, t3, t4, t5) => (
+          rewriteInnermost(t1, context),
+          rewriteInnermost(t2, context),
+          rewriteInnermost(t3, context),
+          rewriteInnermost(t4, context),
+          rewriteInnermost(t5, context)).asInstanceOf[A]
 
         case Some(value) => Some(rewriteInnermost(value, context)).asInstanceOf[A]
 

--- a/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
@@ -400,6 +400,8 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
       node match {
         case map: Map[_, _] => map.map(rewriteTopDown(_, context)).asInstanceOf[A]
 
+        case (t1, t2) => (rewriteTopDown(t1, context), rewriteTopDown(t2, context)).asInstanceOf[A]
+
         case Some(value) => Some(rewriteTopDown(value, context)).asInstanceOf[A]
 
         case node: N @unchecked =>
@@ -431,6 +433,8 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
       node match {
         case map: Map[_, _] => map.map(rewriteBottomUp(_, context)).asInstanceOf[A]
 
+        case (t1, t2) => (rewriteBottomUp(t1, context), rewriteBottomUp(t2, context)).asInstanceOf[A]
+
         case Some(value) => Some(rewriteBottomUp(value, context)).asInstanceOf[A]
 
         case node: N @unchecked =>
@@ -459,6 +463,8 @@ class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C 
     else {
       node match {
         case map: Map[_, _] => map.map(rewriteInnermost(_, context)).asInstanceOf[A]
+
+        case (t1, t2) => (rewriteInnermost(t1, context), rewriteInnermost(t2, context)).asInstanceOf[A]
 
         case Some(value) => Some(rewriteInnermost(value, context)).asInstanceOf[A]
 


### PR DESCRIPTION
-Despite handling the case when node is a Map, the rewriting of Maps does not work correctly. This is because Tuple's are not handled, which stops the recursion and prevents rewriting.
-Added a case for Tuple, that solves the described issue.