### PR TITLE
amaissen/fix-plugin-infrastructure-in-resolver

### DIFF
--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -6,13 +6,14 @@
 
 package viper.silver.parser
 
-import scala.collection.Set
-import scala.language.implicitConversions
 import viper.silver.ast.utility.Visitor
-import viper.silver.ast.{Exp, MagicWandOp, Member, NoPosition, Position, Stmt, Type}
 import viper.silver.ast.utility.rewriter.{Rewritable, StrategyBuilder}
+import viper.silver.ast.{Exp, MagicWandOp, Member, NoPosition, Position, Stmt, Type}
 import viper.silver.parser.TypeHelper._
 import viper.silver.verifier.ParseReport
+
+import scala.collection.Set
+import scala.language.implicitConversions
 
 trait Where {
   val pos: (Position, Position)
@@ -1201,7 +1202,8 @@ case class PUnknownEntity() extends PErrorEntity {
 trait PExtender extends PNode{
   def getSubnodes():Seq[PNode] = ???
   def typecheck(t: TypeChecker, n: NameAnalyser):Option[Seq[String]] = ???
-  def namecheck(n: NameAnalyser) = ???
+  def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType):Option[Seq[String]] = ???
+  def namecheck(n: NameAnalyser): Nothing = ???
   def translateMemberSignature(t: Translator): Member = ???
   def translateMember(t: Translator): Member = ???
 

--- a/src/main/scala/viper/silver/parser/Resolver.scala
+++ b/src/main/scala/viper/silver/parser/Resolver.scala
@@ -51,16 +51,32 @@ case class TypeChecker(names: NameAnalyser) {
   }
 
   def check(p: PProgram): Unit = {
+
+    /* [2022-03-14 Alessandro] Domain function declarations, method declarations and ordinary function declarations
+     * must be checked before their application is checked. Especially, this is because type variables in signatures
+     * must be resolved. However, the checks in the following block are independent of each other.
+     */
     p.domains foreach checkFunctions
-    p.domains foreach checkAxioms
     p.fields foreach check
     p.functions foreach checkDeclaration
     p.predicates foreach checkDeclaration
+    p.methods foreach checkDeclaration
+
+    /* [2022-03-14 Alessandro] Unfortunately, there is currently no mechanism of checking some extensions "signature" first
+     * and checking its "body" in a later step. However, there are currently no Extensions planned that would use this
+     * functionality. Hence we check all the extensions after declarations and signatures are checked. This allows
+     * extensions in which there are function, domain function and method applications.
+     */
+    p.extensions foreach checkExtension
+
+    /* [2022-03-14 Alessandro]
+     * The following block of checks must occur after declarations and signatures are checked, but the checks in the block
+     * do not depend on each other. Note that extensions are checked beforehand, which allow function and method alike extensions.
+     */
+    p.domains foreach checkAxioms
     p.functions foreach checkBody
     p.predicates foreach checkBody
-    p.methods foreach checkDeclaration
     p.methods foreach checkBody
-    p.extensions foreach checkExtension
 
 
     /* Report any domain type that couldn't be resolved */

--- a/src/main/scala/viper/silver/parser/Resolver.scala
+++ b/src/main/scala/viper/silver/parser/Resolver.scala
@@ -6,11 +6,12 @@
 
 package viper.silver.parser
 
+import viper.silver.FastMessaging
+import viper.silver.ast.utility.Visitor
+import viper.silver.ast.{LabelledOld, MagicWandOp}
+
 import scala.collection.mutable
 import scala.reflect._
-import viper.silver.ast.{LabelledOld, MagicWandOp}
-import viper.silver.ast.utility.Visitor
-import viper.silver.FastMessaging
 
 /**
  * A resolver and type-checker for the intermediate Viper AST.
@@ -464,7 +465,7 @@ case class TypeChecker(names: NameAnalyser) {
   }
 
   def check(exp: PExp, expected: PType) = exp match {
-    case t: PExtender => t.typecheck(this, names).getOrElse(Nil) foreach (message =>
+    case t: PExtender => t.typecheck(this, names, expected).getOrElse(Nil) foreach (message =>
       messages ++= FastMessaging.message(t, message))
 
     case _ => checkTopTyped(exp, Some(expected))}

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPASTExtension.scala
@@ -29,7 +29,7 @@ case class PDecreasesTuple(tuple: Seq[PExp], condition: Option[PExp] = None)(val
 
   override val getSubnodes: Seq[PNode] = tuple ++ condition
 
-  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
     // require condition to be of type bool
     condition.foreach(c => t.checkTopTyped(c, Some(Bool)))
     tuple.foreach(a => t.checkTopTyped(a, None))
@@ -45,7 +45,7 @@ case class PDecreasesWildcard(condition: Option[PExp] = None)(val pos: (Position
 
   override val getSubnodes: Seq[PNode] = condition.toSeq
 
-  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
     // require condition to be of type bool
     condition.foreach(c => t.checkTopTyped(c, Some(Bool)))
     None
@@ -59,7 +59,7 @@ case class PDecreasesWildcard(condition: Option[PExp] = None)(val pos: (Position
 case class PDecreasesStar()(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PDecreasesClause {
   override val getSubnodes: Seq[PNode] = Nil
 
-  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
     None
   }
 


### PR DESCRIPTION
This PR enhances and fixes the plugin infrastructure by

1. Changing the check order in the `Resolver`
2. Overloading the `typecheck` function of PExtender so that one can check against an expected type.