### PR TITLE
Hash Calculations for Domains

### DIFF
--- a/src/main/scala/viper/silver/utility/Caching.scala
+++ b/src/main/scala/viper/silver/utility/Caching.scala
@@ -7,9 +7,8 @@
 package viper.silver.utility
 
 import java.security.MessageDigest
-
 import viper.silver.ast.pretty.FastPrettyPrinter
-import viper.silver.ast.Node
+import viper.silver.ast.{Domain, DomainAxiom, DomainFunc, Node}
 
 import scala.collection.mutable
 import scala.language.postfixOps
@@ -106,7 +105,17 @@ object CacheHelper {
     new String(MessageDigest.getInstance("MD5").digest(s.getBytes))
   }
   def computeEntityHash(prefix: String, astNode: Node): String = {
-    val node = prefix + s"_<${astNode.getClass.toString()}>_" + FastPrettyPrinter.pretty(astNode)
+    // orders subtrees of `astNode` when their ordering does not matter, i.e. a cache entry for a
+    // similar node that just has a different ordering of its subtrees should be treated as a cache hit
+    val normalizedAstNode = astNode match {
+      case n: Domain =>
+        Domain(n.name, n.functions.sorted, n.axioms.sorted, n.typVars)(n.pos, n.info, n.errT)
+      case n => n
+    }
+    val node = prefix + s"_<${astNode.getClass.toString}>_" + FastPrettyPrinter.pretty(normalizedAstNode)
     CacheHelper.buildHash(node)
   }
+
+  implicit def domainFnOrdering: Ordering[DomainFunc] = Ordering.by(_.name)
+  implicit def domainAxOrdering: Ordering[DomainAxiom] = Ordering.by(ax => FastPrettyPrinter.pretty(ax.exp))
 }

--- a/src/main/scala/viper/silver/utility/Caching.scala
+++ b/src/main/scala/viper/silver/utility/Caching.scala
@@ -116,6 +116,6 @@ object CacheHelper {
     CacheHelper.buildHash(node)
   }
 
-  implicit def domainFnOrdering: Ordering[DomainFunc] = Ordering.by(_.name)
-  implicit def domainAxOrdering: Ordering[DomainAxiom] = Ordering.by(ax => FastPrettyPrinter.pretty(ax.exp))
+  implicit def domainFnOrdering: Ordering[DomainFunc] = Ordering.by(FastPrettyPrinter.pretty(_))
+  implicit def domainAxOrdering: Ordering[DomainAxiom] = Ordering.by(FastPrettyPrinter.pretty(_))
 }

--- a/src/test/scala/EntityHashTests.scala
+++ b/src/test/scala/EntityHashTests.scala
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import viper.silver.ast._
+import viper.silver.utility.CacheHelper
+
+class EntityHashTests extends AnyFunSuite with Matchers {
+
+  val test_prefix = s"Test Entity Hash"
+
+  val domainName: String = "SomeDomain"
+  val f0: DomainFunc = DomainFunc("f0", Seq(), Int)(domainName = domainName)
+  val f1: DomainFunc = DomainFunc("f1", Seq(), Int)(domainName = domainName)
+  val ax0: DomainAxiom = AnonymousDomainAxiom(TrueLit()())(domainName = domainName)
+  val ax1: DomainAxiom = AnonymousDomainAxiom(TrueLit()())(domainName = domainName)
+  val ax2: DomainAxiom = NamedDomainAxiom("ax2", TrueLit()())(domainName = domainName)
+  val ax3: DomainAxiom = NamedDomainAxiom("ax3", TrueLit()())(domainName = domainName)
+
+  private def sameHash(d0: Domain, d1: Domain): Unit = {
+    val d0Hash = CacheHelper.computeEntityHash("", d0)
+    val d1Hash = CacheHelper.computeEntityHash("", d1)
+    d0Hash should be (d1Hash)
+  }
+
+  test(s"$test_prefix: domain hash does not depend on order of domain functions") {
+    val d0: Domain = Domain(domainName, Seq(f0, f1), Seq(), Seq())()
+    val d1: Domain = Domain(domainName, Seq(f1, f0), Seq(), Seq())()
+    sameHash(d0, d1)
+  }
+
+  test(s"$test_prefix: domain hash does not depend on order of unnamed axioms") {
+    val d0: Domain = Domain(domainName, Seq(), Seq(ax0, ax1), Seq())()
+    val d1: Domain = Domain(domainName, Seq(), Seq(ax1, ax0), Seq())()
+    sameHash(d0, d1)
+  }
+
+  test(s"$test_prefix: domain hash does not depend on order of named axioms") {
+    val d0: Domain = Domain(domainName, Seq(), Seq(ax2, ax3), Seq())()
+    val d1: Domain = Domain(domainName, Seq(), Seq(ax3, ax2), Seq())()
+    sameHash(d0, d1)
+  }
+
+  test(s"$test_prefix: domain hash does not depend on order of named and unnamed axioms") {
+    val d0: Domain = Domain(domainName, Seq(), Seq(ax0, ax1, ax2, ax3), Seq())()
+    val d1: Domain = Domain(domainName, Seq(), Seq(ax3, ax1, ax2, ax1), Seq())()
+    sameHash(d0, d1)
+  }
+
+  test(s"$test_prefix: domain hash does not depend on order of domain functions and named and unnamed axioms") {
+    val d0: Domain = Domain(domainName, Seq(f0, f1), Seq(ax0, ax1, ax2, ax3), Seq())()
+    val d1: Domain = Domain(domainName, Seq(f1, f0), Seq(ax3, ax1, ax2, ax1), Seq())()
+    sameHash(d0, d1)
+  }
+}


### PR DESCRIPTION
The hash of a domain should not depend on the precise ordering of its domain functions and domain axioms. This is important when performing cache lookups as a cached verification result can still safely be used even if the some domain functions are in a slightly different order