### PR TITLE
(AdtPlugin) fixes and regression tests for #581

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPASTExtension.scala
@@ -463,7 +463,6 @@ case class PDestructorCall(name: String, rcv: PExp)
   override def args: Seq[PExp] = Seq(rcv)
 
   override def translateExp(t: Translator): Exp = {
-    val actualRcv = t.exp(rcv)
     val so: Option[Map[TypeVar, Type]] = adtSubstitution match {
       case Some(ps) => Some(ps.m.map(kv => TypeVar(kv._1) -> t.ttyp(kv._2)))
       case None => None
@@ -472,6 +471,10 @@ case class PDestructorCall(name: String, rcv: PExp)
       case Some(s) =>
         val adt = t.getMembers()(this.adt.idndef.name).asInstanceOf[Adt]
         assert(s.keys.toSet == adt.typVars.toSet)
+        val actualRcv = rcv match {
+          case pr@PResultLit() => Result(AdtType(adt, s))(t.liftPos(pr))
+          case _ => t.exp(rcv)
+        }
         AdtDestructorApp(adt, name, actualRcv, s)(t.liftPos(this))
       case _ => sys.error("type unification error - should report and not crash")
     }
@@ -496,7 +499,6 @@ case class PDiscriminatorCall(name: PIdnUse, rcv: PExp)
   override def args: Seq[PExp] = Seq(rcv)
 
   override def translateExp(t: Translator): Exp = {
-    val actualRcv = t.exp(rcv)
     val so: Option[Map[TypeVar, Type]] = adtSubstitution match {
       case Some(ps) => Some(ps.m.map(kv => TypeVar(kv._1) -> t.ttyp(kv._2)))
       case None => None
@@ -505,6 +507,10 @@ case class PDiscriminatorCall(name: PIdnUse, rcv: PExp)
       case Some(s) =>
         val adt = t.getMembers()(this.adt.idndef.name).asInstanceOf[Adt]
         assert(s.keys.toSet == adt.typVars.toSet)
+        val actualRcv = rcv match {
+          case pr@PResultLit() => Result(AdtType(adt, s))(t.liftPos(pr))
+          case _ => t.exp(rcv)
+        }
         AdtDiscriminatorApp(adt, name.name, actualRcv, s)(t.liftPos(this))
       case _ => sys.error("type unification error - should report and not crash")
     }

--- a/src/test/resources/adt/issue-581.vpr
+++ b/src/test/resources/adt/issue-581.vpr
@@ -22,10 +22,10 @@ function inv(t: Test): Bool {
 }
 
 // FIXME: this triggers an error: [typechecker.error] expected identifier, but got PAdtConstructor(PIdnDef(A),List())
-// FIXME: see https://github.com/viperproject/silver/issues/581
+// FIXME: due to `PBinExp` losing its information about `parent`, see https://github.com/viperproject/silver/issues/581
 // function baz(): Test
 //     ensures A() == result
-//     // ensures result == A()
+//     ensures result == A()
 // {
 //     A
 // }

--- a/src/test/resources/adt/issue-581.vpr
+++ b/src/test/resources/adt/issue-581.vpr
@@ -12,6 +12,20 @@ function foo(): Test
 function bar(): Test
     ensures result.isB
     ensures result.b == 42
+    ensures inv(result)
 {
     B(42)
 }
+
+function inv(t: Test): Bool {
+    t.isB && t.b > 10
+}
+
+// FIXME: this triggers an error: [typechecker.error] expected identifier, but got PAdtConstructor(PIdnDef(A),List())
+// FIXME: see https://github.com/viperproject/silver/issues/581
+// function baz(): Test
+//     ensures A() == result
+//     // ensures result == A()
+// {
+//     A
+// }

--- a/src/test/resources/adt/issue-581.vpr
+++ b/src/test/resources/adt/issue-581.vpr
@@ -1,0 +1,17 @@
+adt Test {
+    A()
+    B(b: Int)
+}
+
+function foo(): Test
+    ensures result.isA
+{
+    A()
+}
+
+function bar(): Test
+    ensures result.isB
+    ensures result.b == 42
+{
+    B(42)
+}


### PR DESCRIPTION
The new ADT plugin did not handle `result` expressions in post-conditions yet properly. This PR is a patch to fix a couple of corner cases with additional regression tests.