### PR TITLE
Make pretty-printing and parsing consistent

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -736,15 +736,17 @@ case object PermGtOp extends RelOp(">") with PermBinOp
 case object PermGeOp extends RelOp(">=") with PermBinOp
 
 /** Boolean or. */
-case object OrOp extends BoolBinOp with BoolDomainFunc with LeftAssoc {
+case object OrOp extends BoolBinOp with BoolDomainFunc {
   lazy val op = "||"
   lazy val priority = 4
+  lazy val fixity = Infix(RightAssociative)
 }
 
 /** Boolean and. */
-case object AndOp extends BoolBinOp with BoolDomainFunc with LeftAssoc {
+case object AndOp extends BoolBinOp with BoolDomainFunc {
   lazy val op = "&&"
   lazy val priority = 5
+  lazy val fixity = Infix(RightAssociative)
 }
 
 /** Boolean implication. */

--- a/src/main/scala/viper/silver/parser/Translator.scala
+++ b/src/main/scala/viper/silver/parser/Translator.scala
@@ -355,10 +355,14 @@ case class Translator(program: PProgram) {
         val e = exp(pe)
         op match {
           case "-" =>
-            e.typ match {
-              case Int => Minus(e)(pos)
-              case Perm => PermMinus(e)(pos)
-              case _ => sys.error("unexpected type")
+            e match {
+              case IntLit(i) => IntLit(-i)(pos)
+              case _ =>
+                e.typ match {
+                  case Int => Minus(e)(pos)
+                  case Perm => PermMinus(e)(pos)
+                  case _ => sys.error("unexpected type")
+                }
             }
           case "!" => Not(e)(pos)
         }

--- a/src/test/scala/PrettyPrinterTest.scala
+++ b/src/test/scala/PrettyPrinterTest.scala
@@ -32,11 +32,18 @@ class PrettyPrinterTest extends AnyFunSuite with Matchers {
   test("Parsing a pretty-printed 'And' expression should return the same expression") {
     compareToParsed(and(and(tt, tt), tt))
   }
+
   test("Parsing a pretty-printed 'Or' expression should return the same expression") {
     compareToParsed(or(or(tt, tt), tt))
   }
 
+  test("Parsing pretty-printed '-5' should return the same expression") {
+    compareToParsed(IntLit(-5)())
+  }
+
   private def compareToParsed(exp: Exp): Unit = {
+    val declStmt = LocalVarDeclStmt(LocalVarDecl("tmp", exp.typ)())()
+    val assign = LocalVarAssign(declStmt.decl.localVar, exp)()
     compareToParsed(
       Program(
         Nil,
@@ -52,7 +59,7 @@ class PrettyPrinterTest extends AnyFunSuite with Matchers {
             Nil,
             Some(
               Seqn(
-                List(Assert(exp)()),
+                List(declStmt, assign),
                   Nil
                 )()
               )
@@ -71,9 +78,13 @@ class PrettyPrinterTest extends AnyFunSuite with Matchers {
     fw.write(printed)
     fw.close()
 
+    def getExp(program: Program) = {
+      program.methods.head.body.get.ss(1)
+    }
+
     frontend.translate(file.toPath) match {
       case (Some(result), _) =>
-        assert(result == prog, s"${prog} did not match ${result}")
+        assert(getExp(result) == getExp(prog), s"${prog} did not match ${result}")
       case (None, errors) =>
         sys.error("Error occurred during translating: " + errors)
     }


### PR DESCRIPTION
To facilitate debugging, it's useful if `parse(pretty_print(program)) == program` (especially in the case where an AST is constructed directly, as in Prusti).

This PR fixes some discrepencies:

- Operators `&&` and `||` now are right-associative in pretty-printing, to align with parsing behaviour
- For integer literals `i`, `-i` is now parsed as a negative integer literal (rather than `Minus(i)`)