### PR TITLE
add missing Carbon output annotation to cyclic-list.vpr

### DIFF
--- a/src/test/resources/all/chalice/cyclic-list.vpr
+++ b/src/test/resources/all/chalice/cyclic-list.vpr
@@ -40,6 +40,6 @@ method test2(this: Ref)
   x.next := x
 
   //:: ExpectedOutput(application.precondition:insufficient.permission)
-  //:: IgnoreOthers
+  //:: MissingOutput(application.precondition:insufficient.permission, /Carbon/issue/272/)
   assert ((length(x)) == (length(x.next) + 1))
 }


### PR DESCRIPTION
The merged Carbon pull request https://github.com/viperproject/carbon/pull/407 leads to a missing output in the cyclic-list.vpr test. In theory, older versions of Carbon had the same issue, but due to heuristics in the SMT solver this was not observed before.

The corresponding Carbon issue is discussed in https://github.com/viperproject/carbon/issues/272.