### PR TITLE
Fix for Silicon issue 641 and Carbon issue 430

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
+++ b/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
@@ -252,9 +252,9 @@ object QuantifiedPermissions {
               case SourceQuantifiedPermissionAssertion(iqp, Implies(icond, irhs)) if (!irhs.isPure) =>
                 // Since the rhs cannot be a let-binding, we expand the let-expression
                 Forall(iqp.variables, iqp.triggers.map(t => t.replace(v.localVar, e)), Implies(icond, irhs.replace(v.localVar, e))(iqp.pos, iqp.info))(iqp.pos, iqp.info)
-              case iforall@Forall(ivars, itriggers, ibod) =>
+              case iforall@Forall(ivars, itriggers, Implies(icond, ibod)) =>
                 // For all pure parts of the quantifier, we just re-wrap the body into a let.
-                Forall(ivars, itriggers, Let(v, e, ibod)(lt.pos, lt.info))(iforall.pos, iforall.info)
+                Forall(ivars, itriggers, Implies(icond, Let(v, e, ibod)(lt.pos, lt.info))(lt.pos, lt.info))(iforall.pos, iforall.info)
             }
           }
           case _ =>

--- a/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
+++ b/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
@@ -104,7 +104,7 @@ object QuantifiedPermissions {
         case m@Method(_, _, _, pres, posts, _) if m != root =>
           // use only specification of called methods
           pres ++ posts
-        case f@Function(_, _, _, pres, posts, _) if f != root=>
+        case f@Function(_, _, _, pres, posts, _) if false && f != root=>
           // use only specification of called functions
           pres ++ posts
         case _ => Seq(currentRoot)
@@ -137,7 +137,7 @@ object QuantifiedPermissions {
         case m@Method(_, _, _, pres, posts, _) if m != root =>
           // use only specification of called methods
           pres ++ posts
-        case f@Function(_, _, _, pres, posts, _) if f != root =>
+        case f@Function(_, _, _, pres, posts, _) if false && f != root =>
           // use only specification of called functions
           pres ++ posts
         case _ => Seq(currentRoot)
@@ -244,6 +244,19 @@ object QuantifiedPermissions {
 
             desugarSourceQuantifiedPermissionSyntax(Forall(vars ++ nestedVars, combinedTriggers, Implies(newCond, nestedRhs)(rhs.pos, rhs.info, rhs.errT))(source.pos,MakeInfoPair(source.info, nested.info),MakeTrafoPair(source.errT,nested.errT)))
 
+          case lt@Let(v, e, bod) => {
+            val forallWithoutLet = Forall(vars, triggers, Implies(cond, bod)(rhs.pos, rhs.info))(source.pos, source.info)
+            // desugar the let-body
+            val desugaredWithoutLet = desugarSourceQuantifiedPermissionSyntax(forallWithoutLet)
+            desugaredWithoutLet.map{
+              case SourceQuantifiedPermissionAssertion(iqp, Implies(icond, irhs)) if (!irhs.isPure) =>
+                // Since the rhs cannot be a let-binding, we expand the let-expression
+                Forall(iqp.variables, iqp.triggers.map(t => t.replace(v.localVar, e)), Implies(icond, irhs.replace(v.localVar, e))(iqp.pos, iqp.info))(iqp.pos, iqp.info)
+              case iforall@Forall(ivars, itriggers, ibod) =>
+                // For all pure parts of the quantifier, we just re-wrap the body into a let.
+                Forall(ivars, itriggers, Let(v, e, ibod)(lt.pos, lt.info))(iforall.pos, iforall.info)
+            }
+          }
           case _ =>
             /* RHS does not need to be desugared (any further) */
             Seq(source)

--- a/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
+++ b/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
@@ -104,7 +104,7 @@ object QuantifiedPermissions {
         case m@Method(_, _, _, pres, posts, _) if m != root =>
           // use only specification of called methods
           pres ++ posts
-        case f@Function(_, _, _, pres, posts, _) if false && f != root=>
+        case f@Function(_, _, _, pres, posts, _) if f != root=>
           // use only specification of called functions
           pres ++ posts
         case _ => Seq(currentRoot)
@@ -137,7 +137,7 @@ object QuantifiedPermissions {
         case m@Method(_, _, _, pres, posts, _) if m != root =>
           // use only specification of called methods
           pres ++ posts
-        case f@Function(_, _, _, pres, posts, _) if false && f != root =>
+        case f@Function(_, _, _, pres, posts, _) if f != root =>
           // use only specification of called functions
           pres ++ posts
         case _ => Seq(currentRoot)

--- a/src/test/resources/all/issues/silicon/0641.vpr
+++ b/src/test/resources/all/issues/silicon/0641.vpr
@@ -2,4 +2,4 @@ field f: Int
 
 method bar(x: Seq[Ref])
   requires forall i: Int, j: Int :: 0 <= i && i < |x| && 0 <= j && j < |x| && i != j ==> x[i] != x[j]
-  requires forall i: Int :: 0 <= i && i < |x| ==> let y == (x[i]) in acc(y.f) && x.f >= 5
+  requires forall i: Int :: 0 <= i && i < |x| ==> let y == (x[i]) in acc(y.f) && y.f >= 5

--- a/src/test/resources/all/issues/silicon/0641.vpr
+++ b/src/test/resources/all/issues/silicon/0641.vpr
@@ -1,0 +1,5 @@
+field f: Int
+
+method bar(x: Seq[Ref])
+  requires forall i: Int, j: Int :: 0 <= i && i < |x| && 0 <= j && j < |x| && i != j ==> x[i] != x[j]
+  requires forall i: Int :: 0 <= i && i < |x| ==> let y == (x[i]) in acc(y.f) && x.f >= 5


### PR DESCRIPTION
The code that transforms foralls of arbitrary forms into several quantifiers that are either pure or QPs that have the expected form did not expect let-expressions.