### PR TITLE
Make simplifier preserve (lack of) well-definedness

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -22,7 +22,7 @@ object Simplifier {
    */
   def simplify(expression: Exp): Exp = {
     /* Always simplify children first, then treat parent. */
-    StrategyBuilder.Slim[Node]({
+    val result = StrategyBuilder.Slim[Node]({
       case root @ Not(BoolLit(literal)) =>
         BoolLit(!literal)(root.pos, root.info)
       case Not(Not(single)) => single
@@ -113,6 +113,8 @@ object Simplifier {
       case root @ Mod(IntLit(left), IntLit(right)) if right != bigIntZero =>
         IntLit((right.abs + (left % right)) % right.abs)(root.pos, root.info)
     }, Traverse.BottomUp) execute[Exp](expression)
+    println(s"$expression -> $result")
+    result
   }
 
   private val bigIntZero = BigInt(0)

--- a/src/test/scala/SimplifierTests.scala
+++ b/src/test/scala/SimplifierTests.scala
@@ -12,6 +12,15 @@ import viper.silver.ast._
 import viper.silver.ast.utility.Simplifier._
 
 class SimplifierTests extends AnyFunSuite with Matchers {
+  test("eq") {
+    val seq = LocalVar("someSeq", SeqType(Bool))()
+    val seqIndex = SeqIndex(
+      seq,
+      IntLit(1)()
+    )()
+    simplify(EqCmp(seqIndex, seqIndex)()) should be(EqCmp(seqIndex, seqIndex)())
+    simplify(EqCmp(seq, seq)()) should be(TrueLit()())
+  }
   test("div") {
     simplify(Div(0, 0)()) should be(Div(0, 0)())
     simplify(Div(8, 2)()) should be(4: IntLit)


### PR DESCRIPTION
Currently, the simplifier converts an expression `s[1] == s[1]` to `true`; however, the original expression may not be well-defined (and Silicon / Carbon would raise an exception accordingly).

This PR makes the simplifier more conservative, such that it only simplifies expressions that are guaranteed (syntactically) to be well-defined.