### PR TITLE
[Termination Plugin] Skip generation of trivial assertions

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
@@ -47,9 +47,8 @@ trait DecreasesCheck extends ProgramManager with ErrorReporter {
     // true literal, their respective disjuncts are simplified or even removed. This ensures that trivial assertions
     // like "assert true" and "assert !true || true" are kept to a minimum.
     (rCondition, gCondition) match {
-      case (_: TrueLit, _: TrueLit) => EmptyStmt
+      case (_, _: TrueLit) => EmptyStmt
       case (_: TrueLit, _) => Assert(gCondition)(errT = errTrafo)
-      case (_, _: TrueLit) => Assert(Not(rCondition)(errT = reTrafo))(errT = errTrafo)
       case (_, _) => Assert(Or(Not(rCondition)(errT = reTrafo), gCondition)(errT = reTrafo))(errT = errTrafo)
     }
   }

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
@@ -48,7 +48,10 @@ trait DecreasesCheck extends ProgramManager with ErrorReporter {
     // like "assert true" and "assert !true || true" are kept to a minimum.
     (rCondition, gCondition) match {
       case (_, _: TrueLit) => EmptyStmt
-      case (_: TrueLit, _) => Assert(gCondition)(errT = errTrafo)
+      case (_: TrueLit, _) =>
+        // gCondition must use reTrafo to produce precise error messages
+        val (pos, info, _) = gCondition.meta
+        Assert(gCondition.withMeta(pos, info, reTrafo))(errT = errTrafo)
       case (_, _) => Assert(Or(Not(rCondition)(errT = reTrafo), gCondition)(errT = reTrafo))(errT = errTrafo)
     }
   }

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/DecreasesCheck.scala
@@ -43,9 +43,15 @@ trait DecreasesCheck extends ProgramManager with ErrorReporter {
     val rCondition = requiredCondition.getOrElse(TrueLit()(errT = reTrafo))
     val gCondition = givenCondition.getOrElse(TrueLit()(errT = reTrafo))
 
-    val or = Or(Not(rCondition)(errT = reTrafo), gCondition)(errT = reTrafo)
-
-    Assert(or)(errT = errTrafo)
+    // Generates the statement "assert !rCondition || gCondition". If either rCondition or gCondition are the
+    // true literal, their respective disjuncts are simplified or even removed. This ensures that trivial assertions
+    // like "assert true" and "assert !true || true" are kept to a minimum.
+    (rCondition, gCondition) match {
+      case (_: TrueLit, _: TrueLit) => EmptyStmt
+      case (_: TrueLit, _) => Assert(gCondition)(errT = errTrafo)
+      case (_, _: TrueLit) => Assert(Not(rCondition)(errT = reTrafo))(errT = errTrafo)
+      case (_, _) => Assert(Or(Not(rCondition)(errT = reTrafo), gCondition)(errT = reTrafo))(errT = errTrafo)
+    }
   }
 
 


### PR DESCRIPTION
Using Viper's termination plugin from Gobra seems to lead to a lot of trivial assertions like `assert true` and `assert !true || true` in the resulting Viper code. This is unnecessary. This PR addresses what seems to me the worst offender. Using this optimization, I was able to remove ~700 lines of code from an example from SCION that originally had ~17000 lines of Viper code.