### PR TITLE
Fix compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ ThisBuild / scalacOptions ++= Seq(
   "-unchecked",                       // Warn on generated code assumptions
   "-feature",                         // Warn on features that requires explicit import
   "-Wunused",                         // Warn on unused imports
-  "-Ypatmat-exhaust-depth", "40"      // Increase depth of pattern matching analysis
+  "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
+  "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
 )
 
 // Enforce UTF-8, instead of relying on properly set locales

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ ThisBuild / scalacOptions ++= Seq(
   "-feature",                         // Warn on features that requires explicit import
   "-Wunused",                         // Warn on unused imports
   "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
-  "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
+  // "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
 )
 
 // Enforce UTF-8, instead of relying on properly set locales

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -358,7 +358,7 @@ trait Info {
       case _ => Seq.empty
     }
 
-  def removeUniqueInfo[T <: Info]: Info = this match {
+  def removeUniqueInfo[T <: Info : ClassTag]: Info = this match {
     case ConsInfo(a, b) => MakeInfoPair(a.removeUniqueInfo[T], b.removeUniqueInfo[T])
     case _: T => NoInfo
     case info => info

--- a/src/main/scala/viper/silver/ast/Ast.scala
+++ b/src/main/scala/viper/silver/ast/Ast.scala
@@ -360,7 +360,7 @@ trait Info {
 
   def removeUniqueInfo[T <: Info]: Info = this match {
     case ConsInfo(a, b) => MakeInfoPair(a.removeUniqueInfo[T], b.removeUniqueInfo[T])
-    case t: T => NoInfo
+    case _: T => NoInfo
     case info => info
   }
 }

--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -389,7 +389,7 @@ case class DomainFuncApp(funcname: String, args: Seq[Exp], typVarMap: Map[TypeVa
   //Strangely, the copy method is not a member of the DomainFuncApp case class,
   //therefore, We need this method that does the copying manually
   def copy(funcname: String = this.funcname, args: Seq[Exp] = this.args, typVarMap: Map[TypeVar, Type] = this.typVarMap): (Position, Info, Type, String, ErrorTrafo) => DomainFuncApp ={
-    DomainFuncApp(this.funcname,args,typVarMap)
+    DomainFuncApp(funcname,args,typVarMap)
   }
 }
 object DomainFuncApp {
@@ -403,7 +403,7 @@ case class BackendFuncApp(backendFunc: BackendFunc, args: Seq[Exp])
                          (val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos)
   extends AbstractDomainFuncApp {
   override lazy val check : Seq[ConsistencyError] = args.flatMap(Consistency.checkPure)
-  override def func = (p: Program) => backendFunc
+  override def func = (_: Program) => backendFunc
   def funcname = backendFunc.name
   override def typ = backendFunc.typ
 }

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -8,7 +8,7 @@ package viper.silver.ast.utility
 
 import viper.silver.ast._
 import viper.silver.ast.utility.rewriter.Traverse
-import viper.silver.parser.{FastParser, FastParserCompanion}
+import viper.silver.parser.FastParserCompanion
 import viper.silver.verifier.ConsistencyError
 import viper.silver.{FastMessage, FastMessaging}
 

--- a/src/main/scala/viper/silver/ast/utility/Functions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Functions.scala
@@ -25,7 +25,7 @@ object Functions {
   def allSubexpressionsIncludingUnfoldings(program: Program)(func: Function): Seq[Exp] = {
     var visitedPredicates = Set[String]()
     var subexpressions = allSubexpressions(func)
-    var unfoldings = new ListBuffer[Unfolding]
+    val unfoldings = new ListBuffer[Unfolding]
     unfoldings ++= (subexpressions map (e => e.deepCollect{case u@Unfolding(_, _) => u})).flatten
     var i = 0
     while (i < unfoldings.length){

--- a/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
@@ -185,7 +185,7 @@ object ViperStrategy {
               newMetaData._3
             }
           }
-          now
+          now.withMeta(newMetaData._1, newMetaData._2, newNodeTrafo)
         } else {
           now
         }

--- a/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/ViperStrategy.scala
@@ -179,7 +179,7 @@ object ViperStrategy {
               Trafos(
                 newMetaData._3.eTransformations,
                 newMetaData._3.rTransformations,
-                newMetaData._3.nTransformations.orElse(Some(n.asInstanceOf[ErrorNode])))
+                newMetaData._3.nTransformations.orElse(Some(n)))
             } else {
               /* Keep already attached transformations (if any) */
               newMetaData._3

--- a/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
@@ -7,6 +7,7 @@
 package viper.silver.ast.utility.rewriter
 import viper.silver.ast.utility.rewriter.Traverse.Traverse
 
+import scala.annotation.unused
 import scala.collection.mutable
 import scala.reflect.runtime.{universe => reflection}
 
@@ -92,7 +93,7 @@ trait StrategyInterface[N <: Rewritable] {
     *                          rewritten.
     * @return Updated node that will be built into the AST
     */
-  protected def preserveMetaData(old: N, now: N, directlyRewritten: Boolean): N = now
+  protected def preserveMetaData(@unused old: N, now: N, @unused directlyRewritten: Boolean): N = now
 }
 
 /**

--- a/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
@@ -6,6 +6,7 @@
 
 package viper.silver.ast.utility.rewriter
 
+import scala.annotation.unused
 import scala.reflect.runtime.{universe => reflection}
 
 /*
@@ -143,7 +144,7 @@ class NMatch[N <: Rewritable : TypeTag](val pred: N => Boolean, val rewrite: Boo
     * @param n node used for traversal
     * @return list of traversal infos
     */
-  def getTransitionInfo(n: Rewritable): Seq[TransitionInfo] = if (rewrite) Seq(MarkedForRewrite()) else Seq.empty[TransitionInfo]
+  def getTransitionInfo(@unused n: Rewritable): Seq[TransitionInfo] = if (rewrite) Seq(MarkedForRewrite()) else Seq.empty[TransitionInfo]
 
 }
 

--- a/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
@@ -140,8 +140,8 @@ class NMatch[N <: Rewritable : TypeTag](val pred: N => Boolean, val rewrite: Boo
 
   /**
     * Provide information about the actions that occur if node n matches on this matcher
-    * @param n node used for traversion
-    * @return list of traversion infos
+    * @param n node used for traversal
+    * @return list of traversal infos
     */
   def getTransitionInfo(n: Rewritable): Seq[TransitionInfo] = if (rewrite) Seq(MarkedForRewrite()) else Seq.empty[TransitionInfo]
 

--- a/src/main/scala/viper/silver/cfg/utility/LoopDetector.scala
+++ b/src/main/scala/viper/silver/cfg/utility/LoopDetector.scala
@@ -8,7 +8,6 @@ package viper.silver.cfg.utility
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import viper.silver.ast.utility.ViperStrategy
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.{Exp, If, Info, Infoed, LocalVar, MakeInfoPair, NoInfo, Seqn, Stmt}
 import viper.silver.cfg._

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -242,7 +242,7 @@ trait SilFrontend extends DefaultFrontend {
                 Succ({e.initProperties(); e})
               }
               else Fail(err_list)
-            case fail @ Parsed.Failure(_, index, extra) =>
+            case fail @ Parsed.Failure(_, index, _) =>
               val msg = fail.trace().longAggregateMsg
               val (line, col) = fp.lineCol.getPos(index)
               Fail(List(ParseError(s"Expected $msg", SourcePosition(file, line, col))))

--- a/src/main/scala/viper/silver/parser/Resolver.scala
+++ b/src/main/scala/viper/silver/parser/Resolver.scala
@@ -488,7 +488,7 @@ case class TypeChecker(names: NameAnalyser) {
 
   def checkTopTyped(exp: PExp, oexpected: Option[PType]): Unit =
   {
-    check(exp, PTypeSubstitution.id)
+    checkInternal(exp)
     if (exp.typ.isValidOrUndeclared && exp.typeSubstitutions.nonEmpty) {
       val etss = oexpected match {
         case Some(expected) if expected.isValidOrUndeclared => exp.typeSubstitutions.flatMap(_.add(exp.typ, expected))
@@ -508,12 +508,7 @@ case class TypeChecker(names: NameAnalyser) {
     }
   }
 
-  def checkInternal(exp: PExp): Unit =
-  {
-    check(exp,PTypeSubstitution.id)
-  }
-
-  def check(exp: PExp, s: PTypeSubstitution) : Unit = {
+  def checkInternal(exp: PExp) : Unit = {
     /**
      * Set the type of 'exp', and check that the actual type is allowed by one of the expected types.
      */

--- a/src/main/scala/viper/silver/plugin/SilverPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPlugin.scala
@@ -13,6 +13,8 @@ import viper.silver.parser.{FastParser, PProgram}
 import viper.silver.reporter.Reporter
 import viper.silver.verifier.{AbstractError, VerificationResult}
 
+import scala.annotation.unused
+
 /** Implement this abstract class in order to give your plugin access to SilFrontend's IO:
   * 1. Reporter,
   * 2. Logger,
@@ -41,7 +43,7 @@ trait SilverPlugin {
     * @param isImported Whether the current input is an imported file or the main file
     * @return Modified source code
     */
-  def beforeParse(input: String, isImported: Boolean): String = input
+  def beforeParse(input: String, @unused isImported: Boolean): String = input
 
   /** Called after parse AST has been constructed but before identifiers are resolved and the program is type checked.
     *

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPASTExtension.scala
@@ -11,6 +11,7 @@ import viper.silver.ast._
 import viper.silver.parser._
 import viper.silver.plugin.standard.adt.PAdtConstructor.findAdtConstructor
 
+import scala.annotation.unused
 import scala.util.{Success, Try}
 
 
@@ -296,7 +297,7 @@ object PAdtOpApp {
     * This method mirrors the functionality in Resolver.scala that handles operation applications, except that it is
     * adapted to work for ADT operator applications.
     */
-  def typecheck(poa: PAdtOpApp)(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+  def typecheck(poa: PAdtOpApp)(t: TypeChecker, @unused n: NameAnalyser): Option[Seq[String]] = {
 
     def getFreshTypeSubstitution(tvs: Seq[PDomainType]): PTypeRenaming =
       PTypeVar.freshTypeSubstitutionPTVs(tvs)

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
@@ -14,9 +14,10 @@ import viper.silver.parser._
 import viper.silver.plugin.standard.adt.encoding.AdtEncoder
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
+import scala.annotation.unused
 
-class AdtPlugin(reporter: viper.silver.reporter.Reporter,
-                logger: ch.qos.logback.classic.Logger,
+class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
+                @unused logger: ch.qos.logback.classic.Logger,
                 config: viper.silver.frontend.SilFrontendConfig,
                 fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
 

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePASTExtension.scala
@@ -30,7 +30,7 @@ case class PPredicateInstance(args: Seq[PExp], idnuse: PIdnUse)(val pos: (Positi
       case p: PPredicate =>
         // type checking should be the same as for PPredicateAccess nodes
         val predicateAccess = PPredicateAccess(args, idnuse)(p.pos)
-        t.check(predicateAccess, PTypeSubstitution.id)
+        t.checkInternal(predicateAccess)
         None
       case _ => Some(Seq("expected predicate"))
     }

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
@@ -16,11 +16,12 @@ import viper.silver.verifier.errors.PreconditionInAppFalse
 import fastparse._
 import viper.silver.parser.FastParserCompanion.whitespace
 
+import scala.annotation.unused
 import scala.collection.immutable.ListMap
 
-class PredicateInstancePlugin(reporter: viper.silver.reporter.Reporter,
-                              logger: ch.qos.logback.classic.Logger,
-                              config: viper.silver.frontend.SilFrontendConfig,
+class PredicateInstancePlugin(@unused reporter: viper.silver.reporter.Reporter,
+                              @unused logger: ch.qos.logback.classic.Logger,
+                              @unused config: viper.silver.frontend.SilFrontendConfig,
                               fp: FastParser)  extends SilverPlugin with ParserPluginTemplate {
 
   import fp.{FP, predAcc, ParserExtension}

--- a/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
@@ -15,9 +15,11 @@ import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 import viper.silver.verifier._
 import viper.silver.verifier.errors.AssertFailed
 
-class RefutePlugin(reporter: viper.silver.reporter.Reporter,
-                   logger: ch.qos.logback.classic.Logger,
-                   config: viper.silver.frontend.SilFrontendConfig,
+import scala.annotation.unused
+
+class RefutePlugin(@unused reporter: viper.silver.reporter.Reporter,
+                   @unused logger: ch.qos.logback.classic.Logger,
+                   @unused config: viper.silver.frontend.SilFrontendConfig,
                    fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
 
   import fp.{FP, keyword, exp, ParserExtension}

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -18,8 +18,10 @@ import viper.silver.verifier._
 import fastparse._
 import viper.silver.parser.FastParserCompanion.whitespace
 
-class TerminationPlugin(reporter: viper.silver.reporter.Reporter,
-                        logger: ch.qos.logback.classic.Logger,
+import scala.annotation.unused
+
+class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
+                        @unused logger: ch.qos.logback.classic.Logger,
                         config: viper.silver.frontend.SilFrontendConfig,
                         fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
   import fp.{FP, keyword, exp, ParserExtension}

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/NestedPredicates.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/NestedPredicates.scala
@@ -56,25 +56,16 @@ trait NestedPredicates extends ProgramManager with ErrorReporter {
         val pred = program.findPredicate(pap.loc.predicateName)
         pred.body match {
           case Some(body) =>
-            if (nestedFunc.isDefined) {
-              val formalArgs = ListMap(pred.formalArgs.map(_.localVar).zip(pap.loc.args): _*)
-              //Generate nested-assumption
-              transformPredicateBody(body.replace(formalArgs), varP, pap.perm)
-            } else {
-              if (nestedFunc.isEmpty) {
-                reportNestedNotDefined(pap.pos)
-              }
-              EmptyStmt
-            }
+            val formalArgs = ListMap(pred.formalArgs.map(_.localVar).zip(pap.loc.args): _*)
+            //Generate nested-assumption
+            transformPredicateBody(body.replace(formalArgs), varP, pap.perm)
           case None => EmptyStmt //Predicate has no body
         }
       }
       Seqn(Seq(assignP, unfold, nested), Seq(varP))()
 
     } else {
-      if (nestedFunc.isEmpty) {
-        reportNestedNotDefined(pap.pos)
-      }
+      reportNestedNotDefined(pap.pos)
       EmptyStmt
     }
   }
@@ -177,9 +168,5 @@ trait NestedPredicates extends ProgramManager with ErrorReporter {
 
   private def reportNestedNotDefined(pos: Position): Unit = {
     reportError(ConsistencyError("nestedPredicates function is needed but not declared.", pos))
-  }
-
-  private def reportPredicateInstanceNotDefined(pos: Position): Unit = {
-    reportError(ConsistencyError("PredicateInstance domain is needed but not declared.", pos))
   }
 }

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -27,13 +27,13 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
 
   def report(msg: Message): Unit = {
     msg match {
-      case AstConstructionFailureMessage(time, result) =>
+      case AstConstructionFailureMessage(time, _) =>
         csv_file.write(s"AstConstructionFailureMessage,${time}\n")
       case AstConstructionSuccessMessage(time) =>
         csv_file.write(s"AstConstructionSuccessMessage,${time}\n")
-      case OverallFailureMessage(verifier, time, result) =>
+      case OverallFailureMessage(_, time, _) =>
         csv_file.write(s"OverallFailureMessage,${time}\n")
-      case OverallSuccessMessage(verifier, time) =>
+      case OverallSuccessMessage(_, time) =>
         csv_file.write(s"OverallSuccessMessage,${time}\n")
       case ExceptionReport(e) =>
         csv_file.write(s"ExceptionReport,${e.toString}\n")
@@ -49,14 +49,14 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
         warnings.foreach(report => {
           csv_file.write(s"WarningsDuringTypechecking,${report}\n")
         })
-      case InvalidArgumentsReport(tool_sig, errors) =>
+      case InvalidArgumentsReport(_, errors) =>
         errors.foreach(error => {
           csv_file.write(s"WarningsDuringParsing,${error}\n")
         })
 
-      case EntitySuccessMessage(verifier, concerning, time, cached) =>
+      case EntitySuccessMessage(_, concerning, time, cached) =>
         csv_file.write(s"EntitySuccessMessage,${concerning.name},${time}, ${cached}\n")
-      case EntityFailureMessage(verifier, concerning, time, result, cached) =>
+      case EntityFailureMessage(_, concerning, time, _, cached) =>
         csv_file.write(s"EntityFailureMessage,${concerning.name},${time}, ${cached}\n")
 
       case _: SimpleMessage | _: CopyrightReport | _: MissingDependencyReport | _: BackendSubProcessReport |
@@ -134,7 +134,7 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
       case WarningsDuringTypechecking(warnings) =>
         warnings.foreach(println)
 
-      case InvalidArgumentsReport(tool_sig, errors) =>
+      case InvalidArgumentsReport(_, errors) =>
         errors.foreach(e => println(s"  ${e.readableMessage}"))
         println( s"Run with just --help for usage and options" )
 
@@ -163,7 +163,7 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
         //println( s"Configuration confirmation: $text" )
       case InternalWarningMessage(_) =>        // TODO  use for progress reporting
         //println( s"Internal warning: $text" )
-      case sm:SimpleMessage =>
+      case _:SimpleMessage =>
         //println( sm.text )
       case _ =>
         println( s"Cannot properly print message of unsupported type: $msg" )

--- a/src/main/scala/viper/silver/testing/BackendTypeTest.scala
+++ b/src/main/scala/viper/silver/testing/BackendTypeTest.scala
@@ -1,12 +1,14 @@
 package viper.silver.testing
 
-import org.scalatest.{BeforeAndAfterAllConfigMap, ConfigMap, FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAllConfigMap, ConfigMap}
 import viper.silver.ast.{And, AnySetContains, Assert, BackendFuncApp, EqCmp, Exhale, Exp, Field, FieldAccess, FieldAccessPredicate, FieldAssign, Fold, Forall, FullPerm, Function, Implies, Inhale, IntLit, LocalVarAssign, LocalVarDecl, Method, NeCmp, Not, Predicate, PredicateAccess, PredicateAccessPredicate, Program, Ref, Result, Seqn, SetType, Stmt}
 import viper.silver.ast.utility.{BVFactory, FloatFactory, RoundingMode}
 import viper.silver.verifier.{Failure, Success, Verifier}
 import viper.silver.verifier.errors.{AssertFailed, PostconditionViolated}
 
-trait BackendTypeTest extends FunSuite with Matchers with BeforeAndAfterAllConfigMap {
+trait BackendTypeTest extends AnyFunSuite with Matchers with BeforeAndAfterAllConfigMap {
 
   def generateTypeCombinationTest(success: Boolean) : (Program, Assert) = {
     val t = if (success) BVFactory(23).typ else FloatFactory(23, 11, RoundingMode.RNE).typ

--- a/src/main/scala/viper/silver/testing/BackendTypeTest.scala
+++ b/src/main/scala/viper/silver/testing/BackendTypeTest.scala
@@ -221,12 +221,12 @@ trait BackendTypeTest extends FunSuite with Matchers with BeforeAndAfterAllConfi
 
   val verifier : Verifier
 
-  override def beforeAll(configMap: ConfigMap) {
+  override def beforeAll(configMap: ConfigMap): Unit = {
     verifier.parseCommandLine(Seq("dummy.vpr"))
     verifier.start()
   }
 
-  override def afterAll(configMap: ConfigMap) {
+  override def afterAll(configMap: ConfigMap): Unit = {
     verifier.stop()
   }
 

--- a/src/main/scala/viper/silver/utility/NameGenerator.scala
+++ b/src/main/scala/viper/silver/utility/NameGenerator.scala
@@ -210,7 +210,7 @@ trait DefaultNameGenerator extends NameGenerator {
             builder.append(replaceableLetters(c))
           }
       }
-      var res = builder.result
+      var res = builder.result()
       while (reservedNames.contains(res)) {
         res = defaultIdent + res
       }

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -218,7 +218,7 @@ object PartialVerificationError { // Note: the apply method is used here to inst
 }
 
 case object NullPartialVerificationError extends PartialVerificationError {
-  def f = x => null
+  def f = _ => null
 }
 
 abstract class AbstractVerificationError extends VerificationError {

--- a/src/main/scala/viper/silver/verifier/VerificationResult.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationResult.scala
@@ -8,6 +8,8 @@ package viper.silver.verifier
 
 import viper.silver.ast._
 
+import scala.annotation.unused
+
 /** Describes the outcome of a verification attempt of a Viper program.
 
   */
@@ -67,7 +69,7 @@ trait AbstractError {
   }
 }
 
-abstract class ParseReport(message: String, pos: Position) extends AbstractError
+abstract class ParseReport(@unused message: String, @unused pos: Position) extends AbstractError
 
 /** A parser error. */
 case class ParseError(message: String, override val pos: Position)


### PR DESCRIPTION
This PR fixes most compiler warnings and related bugs that I identified. To silence warnings about non-used parameters, I tried to use the `@unused` keyword sparingly: IIRC, I only used it on methods that are likely to be overriden. 

There are still 6 warnings that I did not address:
```
[error] /private/tmp/silver/src/main/scala/viper/silver/ast/utility/Consistency.scala:156:10: pattern var a in value $anonfun is never used: use a wildcard `_` or suppress this warning with `a@_`
[error]     for (a@LocalVarAssign(l, _) <- b if argVars.contains(l)) {
[error]          ^
[error] /private/tmp/silver/src/main/scala/viper/silver/ast/utility/Consistency.scala:162:10: pattern var n in value $anonfun is never used: use a wildcard `_` or suppress this warning with `n@_`
[error]     for (n@NewStmt(l, _) <- b if argVars.contains(l)){
[error]          ^
[error] /private/tmp/silver/src/main/scala/viper/silver/ast/utility/rewriter/RegexStrategy.scala:131:22: parameter value ancList in method get is never used
[error]     def get(node: N, ancList: Seq[N]): Option[CTXT] = {
[error]                      ^
[error] /private/tmp/silver/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala:789:20: parameter value n in method updateCustom is never used
[error]   def updateCustom(n: N): ContextC[N, CUSTOM] = {
[error]                    ^
[error] /private/tmp/silver/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala:813:20: parameter value n in method updateCustom is never used
[error]   def updateCustom(n: N): ContextCustom[N, CUSTOM] = {
[error]                    ^
[error] /private/tmp/silver/src/main/scala/viper/silver/plugin/standard/adt/AdtPASTExtension.scala:299:49: parameter value n in method typecheck is never used
[error]   def typecheck(poa: PAdtOpApp)(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
[error]                                                 ^
[error] 6 errors found
```
The first two are spurious (the warnings' cause reported by the compiler does not match what the actual code does) and seem to be a known issue of the scala compiler. The last four are about (suspicious) unused parameters. In particular, for the 3rd warning, it seems that the caller of this method performs some book-keeping to contruct `ancList`, just for it to be ignored. I did not address these issues because I am not comfortable with these parts of the codebase.

I also suggest using the flag `-Xfatal-warnings` in the `sbtOptions` as soon as the remaining warnings are addressed to guarantee that no new warnings are introduced on upcoming changes