### PR TITLE
Breaking up long lines when pretty-printing

### DIFF
--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -47,6 +47,13 @@ sealed trait Exp extends Hashable with Typed with Positioned with Infoed with Tr
    */
  // lazy val proofObligations = Expressions.proofObligations(this)
 
+  override def toString() = {
+   // Carbon relies on expression pretty-printing resulting in a string without line breaks,
+   // so for the special case of directly converting an expression to a string,, we remove all line breaks
+   // the pretty printer might have inserted.
+   super.toString.replaceAll("\n", " ")
+ }
+
 }
 
 // --- Simple integer and boolean expressions (binary and unary operations, literals)

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -528,7 +528,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       case Method(name, formalArgs, formalReturns, pres, posts, body) =>
         group(text("method") <+> name <> nest(defaultIndent, parens(showVars(formalArgs))) <> {
           if (formalReturns.isEmpty) nil
-          else nest(defaultIndent, nil <@> "returns" <+> parens(showVars(formalReturns)))
+          else nest(defaultIndent, line <> "returns" <+> parens(showVars(formalReturns)))
         }) <>
           nest(defaultIndent,
             showContracts("requires", pres) <>

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -373,6 +373,9 @@ trait FastPrettyPrinterBase extends PrettyPrintPrimitives {
     def <+> (dr : Cont) : Cont =
       dl <> space <> dr
 
+    def <++>(dr: Cont): Cont =
+      dl <> line <> dr
+
     def <@> (dr: Cont) : Cont =
       if (dl == nil) dr else if (dr == nil) dl else dl <> line <> dr
   }
@@ -526,10 +529,10 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       case Field(name, typ) =>
         text("field") <+> name <> ":" <+> show(typ)
       case Method(name, formalArgs, formalReturns, pres, posts, body) =>
-        text("method") <+> name <> parens(showVars(formalArgs)) <> {
+        group(text("method") <+> name <> parens(showVars(formalArgs)) <> {
           if (formalReturns.isEmpty) nil
-          else nil <+> "returns" <+> parens(showVars(formalReturns))
-        } <>
+          else nest(defaultIndent, nil <++> "returns" <+> parens(showVars(formalReturns)))
+        }) <>
           nest(defaultIndent,
             showContracts("requires", pres) <>
             showContracts("ensures", posts)
@@ -574,7 +577,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     if (contracts == null)
       line <> name <+> uninitialized
     else
-      lineIfSomeNonEmpty(contracts) <> ssep(contracts map (text(name) <+> show(_)), line)
+      lineIfSomeNonEmpty(contracts) <> ssep(contracts.map(c => text(name) <+> nest(defaultIndent, show(c))), line)
   }
 
   /** Returns `n` lines if at least one element of `s` is non-empty, and an empty document otherwise. */
@@ -644,18 +647,18 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     val stmtDoc = stmt match {
       case NewStmt(target, fields) =>
         show(target) <+> ":=" <+> "new(" <> ssep(fields map (f => value(f.name)), char(',') <> space) <> ")"
-      case LocalVarAssign(lhs, rhs) => show(lhs) <+> ":=" <+> show(rhs)
-      case FieldAssign(lhs, rhs) => show(lhs) <+> ":=" <+> show(rhs)
-      case Fold(e) => text("fold") <+> show(e)
-      case Unfold(e) => text("unfold") <+> show(e)
+      case LocalVarAssign(lhs, rhs) => show(lhs) <+> ":=" <+> nest(defaultIndent, show(rhs))
+      case FieldAssign(lhs, rhs) => show(lhs) <+> ":=" <+> nest(defaultIndent, show(rhs))
+      case Fold(e) => text("fold") <+> nest(defaultIndent, show(e))
+      case Unfold(e) => text("unfold") <+> nest(defaultIndent, show(e))
       case Package(e, proofScript) => text("package") <+> show(e) <+> showBlock(proofScript)
-      case Apply(e) => text("apply") <+> show(e)
-      case Inhale(e) => text("inhale") <+> show(e)
-      case Assume(e) => text("assume") <+> show(e)
-      case Exhale(e) => text("exhale") <+> show(e)
-      case Assert(e) => text("assert") <+> show(e)
+      case Apply(e) => text("apply") <+> nest(defaultIndent, show(e))
+      case Inhale(e) => text("inhale") <+> nest(defaultIndent, show(e))
+      case Assume(e) => text("assume") <+> nest(defaultIndent, show(e))
+      case Exhale(e) => text("exhale") <+> nest(defaultIndent, show(e))
+      case Assert(e) => text("assert") <+> nest(defaultIndent, show(e))
       case MethodCall(mname, args, targets) =>
-        val call = text(mname) <> parens(ssep(args map show, char(',') <> space))
+        val call = text(mname) <> nest(defaultIndent, parens(ssep(args map show, group(char(',') <> line))))
         targets match {
           case Nil => call
           case _ => ssep(targets map show, char(',') <> space) <+> ":=" <+> call
@@ -727,7 +730,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     case PredicateAccess(params, predicateName) =>
       text(predicateName) <> parens(ssep(params map show, char (',') <> space))
     case Unfolding(acc, exp) =>
-      parens(text("unfolding") <+> show(acc) <+> "in" <+> show(exp))
+      group(parens(text("unfolding") <+> nest(defaultIndent, show(acc)) <+> "in" <> nest(defaultIndent, line <> show(exp))))
     case Applying(wand, exp) =>
       parens(text("applying") <+> show(wand) <+> "in" <+> show(exp))
     case Old(exp) =>
@@ -737,22 +740,22 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     case Let(v, exp, body) =>
       parens(text("let") <+> text(v.name) <+> "==" <+> parens(show(exp)) <+> "in" <+> show(body))
     case CondExp(cond, thn, els) =>
-      parens(show(cond) <+> "?" <+> show(thn) <+> ":" <+> show(els))
+      group(parens(show(cond) <+> "?" <> nest(defaultIndent, line <> show(thn) <+> ":" <++> show(els))))
     case Exists(v, triggers, exp) =>
       parens(text("exists") <+> showVars(v) <+> "::" <>
-        (if (triggers.isEmpty) nil else space <> ssep(triggers map show, space)) <+>
-        show(exp))
+        nest(defaultIndent, (if (triggers.isEmpty) nil else space <> ssep(triggers map show, space)) <+>
+        show(exp)))
     case Forall(v, triggers, exp) =>
-      parens(text("forall") <+> showVars(v) <+> "::" <>
-        (if (triggers.isEmpty) nil else space <> ssep(triggers map show, space)) <+>
-        show(exp))
+      group(parens(text("forall") <+> showVars(v) <+> "::" <>
+        nest(defaultIndent, (if (triggers.isEmpty) nil else line <> ssep(triggers map show, group(line))) <++>
+          show(exp))))
     case ForPerm(vars, resource, exp) =>
-      parens(text("forperm")
-        <+> showVars(vars)
-        <+> brackets(show(resource)) <+> "::" <+> show(exp))
+      group(parens(text("forperm")
+        <> nest(defaultIndent, line <> showVars(vars)
+          <+> brackets(show(resource)) <+> "::" <+> show(exp))))
 
     case InhaleExhaleExp(in, ex) =>
-      brackets(show(in) <> char (',') <+> show(ex))
+      group(brackets(show(in) <> char (',') <++> show(ex)))
     case WildcardPerm() =>
       "wildcard"
     case FullPerm() =>
@@ -771,13 +774,13 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     case AccessPredicate(loc, perm) =>
       text("acc") <> parens(show(loc) <> "," <+> show(perm))
     case FuncApp(funcname, args) =>
-      text(funcname) <> parens(ssep(args map show, char (',') <> space))
+      text(funcname) <> parens(ssep(args map show, group(char (',') <> line)))
     case dfa@DomainFuncApp(funcname, args, tvMap) =>
       if (tvMap.nonEmpty)
         // Type may be underconstrained, so to be safe we explicitly print out the type.
-        parens(text(funcname) <> parens(ssep(args map show, char (',') <> space)) <> char(':') <+> show(dfa.typ))
+        parens(text(funcname) <> parens(ssep(args map show, group(char (',') <> line))) <> char(':') <+> show(dfa.typ))
       else
-        text(funcname) <> parens(ssep(args map show, char (',') <> space))
+        text(funcname) <> parens(ssep(args map show, group(char (',') <> line)))
     case BackendFuncApp(func, args) =>
       text(func.name) <> parens(ssep(args map show, char(',') <> space))
     case EmptySeq(elemTyp) =>
@@ -810,38 +813,38 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     case EmptySet(elemTyp) =>
       text("Set[") <> showType(elemTyp) <> "]()"
     case ExplicitSet(elems) =>
-      text("Set") <> parens(ssep(elems map show, char (',') <> space))
+      text("Set") <> parens(ssep(elems map show, group(char (',') <> line)))
     case EmptyMultiset(elemTyp) =>
       text("Multiset[") <> showType(elemTyp) <> "]()"
     case ExplicitMultiset(elems) =>
-      text("Multiset") <> parens(ssep(elems map show, char (',') <> space))
+      text("Multiset") <> parens(ssep(elems map show, group(char (',') <> line)))
     case AnySetUnion(left, right) =>
-      parens(show(left) <+> "union" <+> show(right))
+      group(parens(show(left) <+> "union" <++> show(right)))
     case AnySetIntersection(left, right) =>
-      parens(show(left) <+> "intersection" <+> show(right))
+      group(parens(show(left) <+> "intersection" <++> show(right)))
     case AnySetSubset(left, right) =>
-      parens(show(left) <+> "subset" <+> show(right))
+      group(parens(show(left) <+> "subset" <++> show(right)))
     case AnySetMinus(left, right) =>
-      parens(show(left) <+> "setminus" <+> show(right))
+      group(parens(show(left) <+> "setminus" <++> show(right)))
     case AnySetContains(elem, s) =>
-      parens(show(elem) <+> "in" <+> show(s))
+      group(parens(show(elem) <+> "in" <++> show(s)))
     case AnySetCardinality(s) =>
       surround(show(s),char ('|'))
 
     case EmptyMap(keyType, valueType) =>
       text("Map") <> brackets(showType(keyType) <> "," <> showType(valueType)) <> "()"
     case ExplicitMap(elems) =>
-      text("Map") <> parens(ssep(elems map show, char(',') <> space))
+      text("Map") <> parens(ssep(elems map show, group(char(',') <> line)))
     case Maplet(key, value) =>
       show(key) <+> ":=" <+> show(value)
     case MapLookup(base, key) =>
       show(base) <> brackets(show(key))
     case MapContains(key, base) =>
-      parens(show(key) <+> "in" <+> show(base))
+      group(parens(show(key) <+> "in" <++> show(base)))
     case MapCardinality(base) =>
       surround(show(base), char('|'))
     case MapUpdate(base, key, value) =>
-      show(base) <> brackets(show(key) <+> ":=" <+> show(value))
+      show(base) <> group(brackets(show(key) <+> ":=" <++> show(value)))
     case MapDomain(base) =>
       text("domain") <> parens(show(base))
     case MapRange(base) =>
@@ -886,6 +889,6 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
           toParenDoc(r)
       }
 
-    ld <+> text(b.op) <+> rd
+    group(ld <+> text(b.op) <++> rd)
   }
 }


### PR DESCRIPTION
As suggested in issue #544, this PR adds points for potential line breaks to the pretty printer, which enable the pretty-printer to break up long lines into multiple lines with proper indentation. Our pretty printer actually had that ability all along and had a target line width of 75 characters, but couldn't use it due to lack of possible line breaks.

After:
```
function TreeNode_isRoot(self_1: Ref): Ref
  requires issubtype(typeof(self_1), TreeNode())
  requires self_1 != null
  requires acc(tree(self_1), write)
  ensures issubtype(typeof(result), bool())
{
  __prim__bool___box__((unfolding acc(tree(self_1), write) in
    !object___bool__(self_1.TreeNode_parent)))
}

method main(_cthread_175: Ref, _caller_measures_175: Seq[Measure$], _residue_175: Perm)
  returns (_current_wait_level_175: Perm)
  requires _cthread_175 != null
  requires issubtype(typeof(_cthread_175), Thread_0())
  requires [true,
    perm(MustTerminate(_cthread_175)) == none &&
    ((forperm _r_28: Ref [MustInvokeBounded(_r_28)] :: false) &&
    ((forperm _r_28: Ref [MustInvokeUnbounded(_r_28)] :: false) &&
    ((forperm _r_28: Ref [_r_28.MustReleaseBounded] :: false) &&
    (forperm _r_28: Ref [_r_28.MustReleaseUnbounded] :: false))))]
  ensures [true,
    (forperm _r_27: Ref [MustInvokeBounded(_r_27)] :: false) &&
    ((forperm _r_27: Ref [MustInvokeUnbounded(_r_27)] :: false) &&
    ((forperm _r_27: Ref [_r_27.MustReleaseBounded] :: false) &&
    (forperm _r_27: Ref [_r_27.MustReleaseUnbounded] :: false)))]
{
  var BinarySearchTree_res: Ref
  var target: Ref
  module_names_0 := (module_names_0 union
    Set(_single(2147777202629415036263)))
  assert true &&
    (_single(134778768439155653066375051740024039746) in module_names_0)
  BinarySearchTree_res := new()
  inhale typeof(BinarySearchTree_res) == BinarySearchTree()
  inhale acc(_MaySet(BinarySearchTree_res, 170170373251925421444582457427464176135250765572418), write)
  inhale acc(_MaySet(BinarySearchTree_res, 148310513873082034654315146951689972238776244529474), write)
  _cwl_175 := BinarySearchTree___init__(_cthread_175, _method_measures_175,
    _residue_175, BinarySearchTree_res)
  inhale mytree() == BinarySearchTree_res
  module_names_0 := (module_names_0 union Set(_single(111486386338157)))
  _cwl_175 := BinarySearchTree___setitem__(_cthread_175, _method_measures_175,
    _residue_175, _asserting(_asserting(mytree(), true), true &&
    (_single(111486386338157) in module_names_0)), __prim__int___box__(3), str___create__(3,
    6579570))
  _cwl_175 := BinarySearchTree___setitem__(_cthread_175, _method_measures_175,
    _residue_175, _asserting(_asserting(mytree(), true), true &&
    (_single(111486386338157) in module_names_0)), __prim__int___box__(4), str___create__(4,
    1702194274))
  goto __end
  label __end
  assert (forall i: Int ::i > 0)
}
```

Before:
```
function TreeNode_isRoot(self_1: Ref): Ref
  requires issubtype(typeof(self_1), TreeNode())
  requires self_1 != null
  requires acc(tree(self_1), write)
  ensures issubtype(typeof(result), bool())
{
  __prim__bool___box__((unfolding acc(tree(self_1), write) in !object___bool__(self_1.TreeNode_parent)))
}

method main(_cthread_175: Ref, _caller_measures_175: Seq[Measure$], _residue_175: Perm) returns (_current_wait_level_175: Perm)
  requires _cthread_175 != null
  requires issubtype(typeof(_cthread_175), Thread_0())
  requires [true, perm(MustTerminate(_cthread_175)) == none && ((forperm _r_28: Ref [MustInvokeBounded(_r_28)] :: false) && ((forperm _r_28: Ref [MustInvokeUnbounded(_r_28)] :: false) && ((forperm _r_28: Ref [_r_28.MustReleaseBounded] :: false) && (forperm _r_28: Ref [_r_28.MustReleaseUnbounded] :: false))))]
  ensures [true, (forperm _r_27: Ref [MustInvokeBounded(_r_27)] :: false) && ((forperm _r_27: Ref [MustInvokeUnbounded(_r_27)] :: false) && ((forperm _r_27: Ref [_r_27.MustReleaseBounded] :: false) && (forperm _r_27: Ref [_r_27.MustReleaseUnbounded] :: false)))]
{
  var BinarySearchTree_res: Ref
  module_names_0 := (module_names_0 union Set(_single(6872323072689856351)))
  assert true && (_single(7306086878001066580) in module_names_0)
  BinarySearchTree_res := new()
  inhale typeof(BinarySearchTree_res) == BinarySearchTree()
  inhale acc(_MaySet(BinarySearchTree_res, 170170373251925421444582457427464176135250765572418), write)
  inhale acc(_MaySet(BinarySearchTree_res, 148310513873082034654315146951689972238776244529474), write)
  _cwl_175 := BinarySearchTree___init__(_cthread_175, _method_measures_175, _residue_175, BinarySearchTree_res)
  inhale mytree() == BinarySearchTree_res
  module_names_0 := (module_names_0 union Set(_single(111486386338157)))
  _cwl_175 := BinarySearchTree___setitem__(_cthread_175, _method_measures_175, _residue_175, _asserting(_asserting(mytree(), true), true && (_single(111486386338157) in module_names_0)), __prim__int___box__(3), str___create__(3, 6579570))
  _cwl_175 := BinarySearchTree___setitem__(_cthread_175, _method_measures_175, _residue_175, _asserting(_asserting(mytree(), true), true && (_single(111486386338157) in module_names_0)), __prim__int___box__(4), str___create__(4, 1702194274))
  goto __end
  label __end
  assert forall i: Int :: i > 0
}
```