### PR TITLE
[Termination Plugin] Extend Expr Support

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -6,6 +6,7 @@
 
 package viper.silver.ast.utility
 
+import viper.silver.ast.utility.Statements.EmptyStmt
 import viper.silver.ast._
 import viper.silver.ast.utility.rewriter._
 
@@ -15,14 +16,15 @@ import viper.silver.ast.utility.rewriter._
 object Simplifier {
 
   /**
-   * Simplify `expression`, in particular by making use of literals. For
+   * Simplify `n`, in particular by making use of literals. For
    * example, `!true` is replaced by `false`. Division and modulo with divisor
    * 0 are not treated. Note that an expression with non-terminating evaluation due to endless recursion
    * might be transformed to terminating expression.
    */
-  def simplify(expression: Exp): Exp = {
+  def simplify[N <: Node](n: N): N = {
     /* Always simplify children first, then treat parent. */
     StrategyBuilder.Slim[Node]({
+      // expression simplifications
       case root @ Not(BoolLit(literal)) =>
         BoolLit(!literal)(root.pos, root.info)
       case Not(Not(single)) => single
@@ -112,7 +114,16 @@ object Simplifier {
         IntLit(left / right)(root.pos, root.info)
       case root @ Mod(IntLit(left), IntLit(right)) if right != bigIntZero =>
         IntLit((right.abs + (left % right)) % right.abs)(root.pos, root.info)
-    }, Traverse.BottomUp) execute[Exp](expression)
+
+      // statement simplifications
+      case Seqn(EmptyStmt, _) => EmptyStmt // remove empty Seqn (including unnecessary scopedDecls)
+      case s@Seqn(ss, scopedDecls) if ss.contains(EmptyStmt) => // remove empty statements
+        val newSS = ss.filterNot(_ == EmptyStmt)
+        Seqn(newSS, scopedDecls)(s.pos, s.info, s.errT)
+      case If(_, EmptyStmt, EmptyStmt) => EmptyStmt // remove empty If clause
+      case If(TrueLit(), thn, _) => thn // remove trivial If conditions
+      case If(FalseLit(), _, els) => els // remove trivial If conditions
+    }, Traverse.BottomUp) execute n
   }
 
   private val bigIntZero = BigInt(0)

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
@@ -6,10 +6,10 @@
 
 package viper.silver.plugin.standard.termination.transformation
 
-import viper.silver.ast.{And, AnySetExp, Exp, Stmt, _}
+import viper.silver.ast._
 import viper.silver.ast.utility.Statements.EmptyStmt
-import viper.silver.ast.utility.ViperStrategy
-import viper.silver.ast.utility.rewriter.{ContextCustom, RepeatedStrategy, Strategy, Traverse}
+import viper.silver.ast.utility.{Expressions, ViperStrategy}
+import viper.silver.ast.utility.rewriter.{ContextCustom, Strategy, Traverse}
 import viper.silver.verifier.ConsistencyError
 
 /**
@@ -84,39 +84,7 @@ trait ExpTransformer extends ProgramManager with ErrorReporter {
           Seqn(Seq(right), Nil)()
       }
       Seqn(Seq(left, rightSCE), Nil)()
-    case ase: AnySetExp => ase match {
-      case exp: AnySetUnExp => Seqn(Seq(transformExp(exp.exp, c)), Nil)(ase.pos)
-      case exp: AnySetBinExp => Seqn(Seq(transformExp(exp.left, c), transformExp(exp.right, c)), Nil)(ase.pos)
-      case MapDomain(base) => Seqn(Seq(transformExp(base, c)), Nil)(ase.pos)
-      case MapRange(base) => Seqn(Seq(transformExp(base, c)), Nil)(ase.pos)
-    }
-    // remaining `SetExp`:
-    case EmptySet(_) => EmptyStmt
-    case e@ExplicitSet(elems) => Seqn(elems.map(transformExp(_, c)), Nil)(e.pos)
-    // remaining `MultisetExp`:
-    case EmptyMultiset(_) => EmptyStmt
-    case e@ExplicitMultiset(elems) => Seqn(elems.map(transformExp(_, c)), Nil)(e.pos)
-    // remaining `SeqExp`:
-    case EmptySeq(_) => EmptyStmt
-    case e@ExplicitSeq(elems) => Seqn(elems.map(transformExp(_, c)), Nil)(e.pos)
-    case e@RangeSeq(low, high) => Seqn(Seq(transformExp(low, c), transformExp(high, c)), Nil)(e.pos)
-    case e@SeqAppend(left, right) => Seqn(Seq(transformExp(left, c), transformExp(right, c)), Nil)(e.pos)
-    case e@SeqIndex(s, idx) => Seqn(Seq(transformExp(s, c), transformExp(idx, c)), Nil)(e.pos)
-    case e@SeqTake(s, n) => Seqn(Seq(transformExp(s, c), transformExp(n, c)), Nil)(e.pos)
-    case e@SeqDrop(s, n) => Seqn(Seq(transformExp(s, c), transformExp(n, c)), Nil)(e.pos)
-    case e@SeqContains(elem, s) => Seqn(Seq(transformExp(elem, c), transformExp(s, c)), Nil)(e.pos)
-    case e@SeqUpdate(s, idx, elem) => Seqn(Seq(transformExp(s, c), transformExp(idx, c), transformExp(elem, c)), Nil)(e.pos)
-    case e@SeqLength(s) => Seqn(Seq(transformExp(s, c)), Nil)(e.pos)
-    // remaining `MapExp`:
-    case EmptyMap(_, _) => EmptyStmt
-    case e@ExplicitMap(elems) => Seqn(elems.map(transformExp(_, c)), Nil)(e.pos)
-    case e@Maplet(key, value) => Seqn(Seq(transformExp(key, c), transformExp(value, c)), Nil)(e.pos)
-    case e@MapCardinality(base) => Seqn(Seq(transformExp(base, c)), Nil)(e.pos)
-    case e@MapContains(key, base) => Seqn(Seq(transformExp(key, c), transformExp(base, c)), Nil)(e.pos)
-    case e@MapLookup(base, key) => Seqn(Seq(transformExp(base, c), transformExp(key, c)), Nil)(e.pos)
-    case e@MapUpdate(base, key, value) => Seqn(Seq(transformExp(base, c), transformExp(key, c), transformExp(value, c)), Nil)(e.pos)
 
-    case u: UnExp => transformExp(u.exp, c)
     case _: Literal => EmptyStmt
     case _: AbstractLocalVar => EmptyStmt
     case _: AbstractConcretePerm => EmptyStmt
@@ -132,32 +100,36 @@ trait ExpTransformer extends ProgramManager with ErrorReporter {
     case fa: Forall =>
       // we turn the quantified variables into local variables with arbitrary value and show that the expression holds
       // for arbitrary values, which is similar to a forall introduction
-      val (freshDecls, transformedExp, _) = substituteWithFreshVars(fa.variables, fa.exp)
+      val (localDeclMapping, transformedExp) = substituteWithFreshVars(fa.variables, fa.exp)
       val expressionStmt = transformExp(transformedExp, c)
-      Seqn(Seq(expressionStmt), freshDecls)(fa.pos, fa.info, fa.errT)
+      Seqn(Seq(expressionStmt), localDeclMapping.map(_._2))(fa.pos, fa.info, fa.errT)
     case fp: ForPerm =>
       // let's pick arbitrary values for the quantified variables and check the body given that the current heap has
       // sufficient permissions
-      val (freshDecls, transformedExp, varMapping) = substituteWithFreshVars(fp.variables, fp.exp)
-      val transformedRes = substituteVars(varMapping, fp.resource)
+      val (localDeclMapping, transformedExp) = substituteWithFreshVars(fp.variables, fp.exp)
+      val transformedRes = applySubstitution(localDeclMapping, fp.resource)
       val expressionStmt = transformExp(transformedExp, c)
       val killBranchStmt = Inhale(FalseLit()(e.pos, e.info, e.errT))(e.pos, e.info, e.errT)
       val thnStmt = Seqn(Seq(expressionStmt, killBranchStmt), Nil)(e.pos, e.info, e.errT)
       val ifCond = GtCmp(CurrentPerm(transformedRes)(e.pos, e.info, e.errT), NoPerm()(e.pos, e.info, e.errT))(e.pos, e.info, e.errT)
       val ifStmt = If(ifCond, thnStmt, EmptyStmt)(e.pos, e.info, e.errT)
-      Seqn(Seq(ifStmt), freshDecls)(e.pos, e.info, e.errT)
+      Seqn(Seq(ifStmt), localDeclMapping.map(_._2))(e.pos, e.info, e.errT)
     case ex: Exists =>
       // we perform existential elimination by retrieving witnesses for the quantified variables
-      val (freshDecls, transformedExp, _) = substituteWithFreshVars(ex.variables, ex.exp)
+      val (localDeclMapping, transformedExp) = substituteWithFreshVars(ex.variables, ex.exp)
       // we can't use an assume statement at this point because the `assume`s have already been rewritten
       // furthermore, Viper only allows pure existentially quantified expressions
       val inhaleWitnesses = Inhale(transformedExp)(ex.pos, ex.info, ex.errT)
       val expressionStmt = transformExp(transformedExp, c)
-      Seqn(Seq(inhaleWitnesses, expressionStmt), freshDecls)(ex.pos, ex.info, ex.errT)
+      Seqn(Seq(inhaleWitnesses, expressionStmt), localDeclMapping.map(_._2))(ex.pos, ex.info, ex.errT)
     case fa: FuncLikeApp =>
       val argStmts = fa.args.map(transformExp(_, c))
       Seqn(argStmts, Nil)()
     case e: ExtensionExp => reportUnsupportedExp(e)
+
+    case _ =>
+      val sub = e.subExps.map(transformExp(_, c))
+      Seqn(sub, Nil)()
   }
 
   /**
@@ -202,61 +174,24 @@ trait ExpTransformer extends ProgramManager with ErrorReporter {
   }
 
   /**
-    * Turns `vars` into new local variable declarations with a unique name and replaces their occurrences in `exp`.
-    * The new local variables declarations and the transformed expression are returned
+    * Turns `vars` into new local variable declarations with a unique name and replaces the corresponding local variable uses in `exp`.
+    * Returns a mapping of old variable declarations to new ones and the transformed expression
     */
-  protected def substituteWithFreshVars(vars: Seq[LocalVarDecl], exp: Exp): (Seq[LocalVarDecl], Exp, Seq[(LocalVarDecl, String)]) = {
-    val declMapping = vars.map(decl => decl -> uniqueName(decl.name))
-    val freshDecls = declMapping.map {
-      case (oldDecl, freshName) => LocalVarDecl(freshName, oldDecl.typ)(oldDecl.pos, oldDecl.info, oldDecl.errT)
-    }
-    val transformedExp = substituteVars(declMapping, exp)
-    (freshDecls, transformedExp, declMapping)
-  }
-
-  protected def substituteVars[T <: Node](varMapping: Seq[(LocalVarDecl, String)], n: T): T = {
-    n.transform({
-      case v@LocalVar(name, typ) => varMapping
-        // check whether the local variable is in the map of variables that should be replaced:
-        .collectFirst { case (decl, freshName) if decl.name == name => freshName }
-        // replace it by a new local variable:
-        .map(freshName => LocalVar(freshName, typ)(v.pos, v.info, v.errT))
-        // keep the variable unchanged if no replacement should happen:
-        .getOrElse(v)
-    }, Traverse.TopDown)
+  protected def substituteWithFreshVars[E <: Exp](vars: Seq[LocalVarDecl], exp: E): (Seq[(LocalVarDecl, LocalVarDecl)], E) = {
+    val declMapping = vars.map(oldDecl =>
+      oldDecl -> LocalVarDecl(uniqueName(oldDecl.name), oldDecl.typ)(oldDecl.pos, oldDecl.info, oldDecl.errT))
+    val transformedExp = applySubstitution(declMapping, exp)
+    (declMapping, transformedExp)
   }
 
   /**
-   * The simplifyStmts Strategy can be used to simplify statements
-   * by e.g. removing or combining nested Seqn or If clauses.
-   * This is in particular useful for the expression to statement transformer
-   * because this often creates nested and empty Seqn and If clauses.
-   *
-   * This is a repeating strategy because the removal of unneccessary unfold/fold statements requires EmptyStmts
-   * to be removed beforehand. Therefore, it should only be used with an maximum number of iterations (2).
-   *
-   */
-  val simplifyStmts: RepeatedStrategy[Node] = ViperStrategy.Slim({
-    case Seqn(EmptyStmt, _) => // remove empty Seqn (including unnecessary scopedDecls)
-      EmptyStmt
-    case s@Seqn(Seq(Seqn(ss, scopedDecls2)), scopedDecls1) => // combine nested Seqn
-      Seqn(ss, scopedDecls1 ++ scopedDecls2)(s.pos, s.info, s.errT)
-    case s@Seqn(ss, scopedDecls) if ss.contains(EmptyStmt) => // remove empty statements
-      val newSS = ss.filterNot(_ == EmptyStmt)
-      Seqn(newSS, scopedDecls)(s.pos, s.info, s.errT)
-    case Seqn(Seq(Unfold(acc1), Fold(acc2)), _) if acc1 == acc2 => // remove unfold/fold with nothing in between
-      EmptyStmt
-    case If(_, EmptyStmt, EmptyStmt) => // remove empty If clause
-      EmptyStmt
-    case i@If(c, EmptyStmt, els) => // change If with only els to If with only thn
-      If(Not(c)(c.pos), els, EmptyStmt)(i.pos, i.info, i.errT)
-    case i@If(c1, Seqn(Seq(If(c2, thn, EmptyStmt)), Nil), EmptyStmt) => // combine nested if clauses
-      If(And(c1, c2)(), thn, EmptyStmt)(i.pos, i.info, i.errT)
-    case If(TrueLit(), thn, _) => thn // remove trivial If conditions (in particular effective together with the next 2 simplifications)
-    case And(TrueLit(), rhs) => rhs // simplify conjunctions
-    case And(lhs, TrueLit()) => lhs // simplify conjunctions
-  }, Traverse.BottomUp)
-    .repeat
+    * Replaces uses of local variables in `exp` based on `mapping`.
+    * `mapping` maps local variable declarations to new declarations and this transformation replaces the corresponding
+    * local variable uses.
+    */
+  protected def applySubstitution[E <: Exp](mapping: Seq[(LocalVarDecl, LocalVarDecl)], exp: E): E = {
+    Expressions.instantiateVariables(exp, mapping.map(_._1.localVar), mapping.map(_._2.localVar))
+  }
 }
 
 trait ExpressionContext {

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -9,7 +9,7 @@ package viper.silver.plugin.standard.termination.transformation
 import org.jgrapht.graph.{DefaultDirectedGraph, DefaultEdge}
 import viper.silver.ast.utility.Statements.EmptyStmt
 import viper.silver.ast.utility.rewriter.Traverse
-import viper.silver.ast.utility.ViperStrategy
+import viper.silver.ast.utility.{Simplifier, ViperStrategy}
 import viper.silver.ast.{And, Bool, ErrTrafo, Exp, FalseLit, FuncApp, Function, LocalVarDecl, Method, Node, NodeTrafo, Old, Result, Seqn, Stmt}
 import viper.silver.plugin.standard.termination.{DecreasesSpecification, FunctionTerminationError}
 import viper.silver.verifier.errors.AssertFailed
@@ -53,7 +53,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
         val context = FContext(f)
 
         val proofMethodBody: Stmt = {
-          val stmt: Stmt = simplifyStmts.execute(transformExp(f.body.get, context))
+          val stmt: Stmt = Simplifier.simplify(transformExp(f.body.get, context))
           if (requireNestedInfo) {
             addNestedPredicateInformation.execute(stmt)
           } else {
@@ -88,7 +88,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
           .reduce((e, p) => And(e, p)())
 
         val proofMethodBody: Stmt = {
-          val stmt: Stmt = simplifyStmts.execute(transformExp(posts, context))
+          val stmt: Stmt = Simplifier.simplify(transformExp(posts, context))
           if (requireNestedInfo) {
             addNestedPredicateInformation.execute(stmt)
           } else {
@@ -113,7 +113,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
         // concatenate all pres
         val pres = f.pres.reduce((e, p) => And(e, p)())
 
-        val proofMethodBody: Stmt = simplifyStmts.execute(transformExp(pres, context))
+        val proofMethodBody: Stmt = Simplifier.simplify(transformExp(pres, context))
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, Nil, Nil,

--- a/src/test/resources/termination/functions/expressions/access.vpr
+++ b/src/test/resources/termination/functions/expressions/access.vpr
@@ -1,0 +1,25 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+field g: Int
+
+function test1(x: Ref): Bool
+    decreases
+    requires acc(x.f) && acc(x.g)
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    nonTerminating(x)
+}
+
+function test2(x: Ref): Bool
+    decreases
+    requires acc(x.f) && acc(x.f) && acc(x.g)
+{
+    nonTerminating(x)
+}
+
+function nonTerminating(x: Ref): Bool
+    decreases *

--- a/src/test/resources/termination/functions/expressions/exists.vpr
+++ b/src/test/resources/termination/functions/expressions/exists.vpr
@@ -1,0 +1,51 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+
+function test(x: Ref): Bool
+    decreases
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    exists x2: Ref :: x == x2 && nonTerminating(x2)
+}
+
+function test2(): Bool
+    decreases
+{
+    // in general `partiallyTerminating` is non-terminating
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    exists x2: Int :: partiallyTerminating(x2)
+}
+
+function test3(x: Int): Bool
+    decreases
+    requires x == 42
+{
+    // `partiallyTerminating` terminates for input `42` so this is fine
+    exists x2: Int :: x == x2 && partiallyTerminating(x2)
+}
+
+function test4(x: Int): Bool
+    decreases
+{
+    // in general `partiallyTerminating` is non-terminating
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    (exists x2: Int :: x == x2) && partiallyTerminating(x)
+}
+
+function test5(x: Int): Bool
+    decreases
+{
+    // this is fine due to short-circuiting
+    (exists x2: Int :: x == x2 && x != x2) && partiallyTerminating(x)
+}
+
+function nonTerminating(x: Ref): Bool
+    decreases *
+
+function partiallyTerminating(x: Int): Bool
+    decreases if x == 42
+    decreases *

--- a/src/test/resources/termination/functions/expressions/forall.vpr
+++ b/src/test/resources/termination/functions/expressions/forall.vpr
@@ -1,0 +1,25 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+
+function test(x: Ref): Bool
+    decreases
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    requires forall x2: Ref :: x == x2 ==> acc(x2.f) && nonTerminating(x2)
+{
+    true
+}
+
+function test2(x: Ref): Bool
+    decreases
+    // this is fine because `nonTerminating(x2)` is not reachable
+    requires forall x2: Ref :: x == x2 ==> false && nonTerminating(x2)
+{
+    true
+}
+
+function nonTerminating(x: Ref): Bool
+    decreases *

--- a/src/test/resources/termination/functions/expressions/forperm.vpr
+++ b/src/test/resources/termination/functions/expressions/forperm.vpr
@@ -1,0 +1,26 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+
+function test(x: Ref): Bool
+    decreases
+    requires acc(x.f)
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    requires [forperm x2: Ref [x2.f] :: nonTerminating(x2.f), true]
+{
+    true
+}
+
+function test2(x: Ref): Bool
+    decreases
+    // current heap does not hold any permissions so `nonTermination` is not evaluated
+    requires [forperm x2: Ref [x2.f] :: nonTerminating(x2.f), true]
+{
+    true
+}
+
+function nonTerminating(v: Int): Bool
+    decreases *

--- a/src/test/resources/termination/functions/expressions/unfolding.vpr
+++ b/src/test/resources/termination/functions/expressions/unfolding.vpr
@@ -1,0 +1,40 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+
+predicate foo(x: Ref)
+{
+    acc(x.f) && x.f == 42
+}
+
+function test(x: Ref): Bool
+    decreases
+    requires foo(x)
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    unfolding foo(x) in nonTerminating(x)
+}
+
+function test2(x: Ref): Bool
+    decreases
+    requires foo(x)
+{
+    unfolding foo(x) in partiallyTerminating(x)
+}
+
+function test3(x: Ref): Bool
+    decreases
+    requires foo(x)
+    // `unfolding` should indeed only temporarily unfold the predicate such that `nonTerminating(x)` is not reachable:
+    requires [true, (unfolding foo(x) in true) && (perm(x.f) > none ? nonTerminating(x) : true)]
+
+function nonTerminating(x: Ref): Bool
+    decreases *
+
+function partiallyTerminating(x: Ref): Bool
+    requires acc(x.f, wildcard)
+    decreases if x.f == 42
+    decreases *

--- a/src/test/resources/termination/functions/expressions/unfolding.vpr
+++ b/src/test/resources/termination/functions/expressions/unfolding.vpr
@@ -25,12 +25,6 @@ function test2(x: Ref): Bool
     unfolding foo(x) in partiallyTerminating(x)
 }
 
-function test3(x: Ref): Bool
-    decreases
-    requires foo(x)
-    // `unfolding` should indeed only temporarily unfold the predicate such that `nonTerminating(x)` is not reachable:
-    requires [true, (unfolding foo(x) in true) && (perm(x.f) > none ? nonTerminating(x) : true)]
-
 function nonTerminating(x: Ref): Bool
     decreases *
 

--- a/src/test/resources/termination/functions/expressions/wildcard.vpr
+++ b/src/test/resources/termination/functions/expressions/wildcard.vpr
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+field f: Int
+
+function test(x: Ref): Bool
+    decreases
+    requires acc(x.f, wildcard)
+{
+    true
+}


### PR DESCRIPTION
The termination plugin uses `transformExp` to turn preconditions, function bodies, and postconditions into a statement.
Each statement is then used as the body of a new method to prove termination for the corresponding expression.
So far, the transformer was not able to handle wildcard permission amounts and forall & existential quantifiers. Additionally, the support for set and multiset-related operations was limited.

This PR extends the transformer to handle these expressions as well.
The transformation for forall quantifiers performs a forall introduction by showing that the expression terminates for an arbitrary choice of quantified variable values.
In the case of existential quantifiers, we obtain the witness and thus perform existential elimination