### PR TITLE
Make values optional in counterexamples

### DIFF
--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -28,6 +28,12 @@ case class SuffixedExpressionGenerator[E <: PExp](func: PExp => E) extends (PExp
 object FastParserCompanion {
   import fastparse._
 
+  val whitespaceWithoutNewlineOrComments = {
+    import NoWhitespace._
+    implicit ctx: ParsingRun[_] =>
+      NoTrace((" " | "\t").rep)
+  }
+
   implicit val whitespace = {
     import NoWhitespace._
     implicit ctx: ParsingRun[_] =>

--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -1,17 +1,23 @@
 package viper.silver.verifier
 
 import fastparse._
-import viper.silver.parser.FastParserCompanion.whitespace
-
 object ModelParser {
+  def modelEntry[_: P]: P[(String, ModelEntry)] = {
+    implicit val ws = viper.silver.parser.FastParserCompanion.whitespaceWithoutNewlineOrComments
+    P(idnuse ~ "->" ~ definition.?).map {
+      case (i, Some(e)) => (i, e)
+      case (i, None) => (i, UnspecifiedEntry)
+    }
+  }
+
+  import viper.silver.parser.FastParserCompanion.whitespace
+
   // note that the dash/minus character '-' needs to be escaped by double backslashes such that it is not interpreted as a range
   def identifier[_: P]: P[Unit] = P(CharIn("0-9", "A-Z", "a-z", "[]\"'#+\\-*/:=!$_@<>.%~").repX(1))
 
   def idnuse[_: P]: P[String] = P(identifier).!.filter(a => a != "else" && a != "let" && a != "->")
 
   def numeral[_: P]: P[Unit] = P(CharIn("0-9").repX(1))
-
-  def modelEntry[_: P]: P[(String, ModelEntry)] = P(idnuse ~ "->" ~ definition)
 
   def definition[_: P]: P[ModelEntry] = P(mapping | value)
 

--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -2,6 +2,7 @@ package viper.silver.verifier
 
 import fastparse._
 object ModelParser {
+  
   def modelEntry[_: P]: P[(String, ModelEntry)] = {
     // Do not allow newlines between "->" and the definition.
     // Otherwise, if there is no definition, we could parse the id in the next line as the value here.

--- a/src/main/scala/viper/silver/verifier/ModelParser.scala
+++ b/src/main/scala/viper/silver/verifier/ModelParser.scala
@@ -3,6 +3,8 @@ package viper.silver.verifier
 import fastparse._
 object ModelParser {
   def modelEntry[_: P]: P[(String, ModelEntry)] = {
+    // Do not allow newlines between "->" and the definition.
+    // Otherwise, if there is no definition, we could parse the id in the next line as the value here.
     implicit val ws = viper.silver.parser.FastParserCompanion.whitespaceWithoutNewlineOrComments
     P(idnuse ~ "->" ~ definition.?).map {
       case (i, Some(e)) => (i, e)
@@ -10,6 +12,7 @@ object ModelParser {
     }
   }
 
+  // Late import s.t. we can unambiguously use a different whitespace definition in the modelEntry rule above.
   import viper.silver.parser.FastParserCompanion.whitespace
 
   // note that the dash/minus character '-' needs to be escaped by double backslashes such that it is not interpreted as a range

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -164,7 +164,13 @@ trait ErrorMessage {
 trait VerificationError extends AbstractError with ErrorMessage {
   def reason: ErrorReason
   def readableMessage(withId: Boolean = false, withPosition: Boolean = false): String
-  override def readableMessage: String = readableMessage(false, true) + failureContexts.map(e => e.toString).mkString("\n")
+  override def readableMessage: String = {
+    val msg = readableMessage(false, true)
+    if (failureContexts.isEmpty)
+      msg
+    else
+      msg + "\n" + failureContexts.map(e => e.toString).mkString("\n")
+  }
   def loggableMessage: String = s"$fullId-$pos" + (if (cached) "-cached" else "")
   def fullId = s"$id:${reason.id}"
   var failureContexts: Seq[FailureContext] = Seq() //TODO: make immutable


### PR DESCRIPTION
This is to accomodate the counterexamples returned by new Boogie versions.
Also, I slightly cleaned up pretty-printing of FailureContexts, so that users no longer see things like
```
message (position)FailureContextImpl(Some(x1 -> 1
y1 -> Ref!12!val))
```