### PR TITLE
Extend Extension Stmt Capabilities

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -437,8 +437,8 @@ object MethodWithLabelsInScope {
                  (pos: Position = NoPosition, info: Info = NoInfo, errT: ErrorTrafo = NoTrafos): Method = {
     val newBody = body match {
       case Some(actualBody) =>
-        val newScopedDecls = actualBody.scopedDecls ++ actualBody.deepCollect({case l: Label => l})
-        Some(actualBody.copy(scopedDecls = newScopedDecls)(actualBody.pos, actualBody.info, actualBody.errT))
+        val newScopedDecls = actualBody.scopedSeqnDeclarations ++ actualBody.deepCollect({case l: Label => l})
+        Some(actualBody.copy(scopedSeqnDeclarations = newScopedDecls)(actualBody.pos, actualBody.info, actualBody.errT))
       case _ => body
     }
     Method(name, formalArgs, formalReturns, pres, posts, newBody)(pos, info, errT)

--- a/src/main/scala/viper/silver/ast/Statement.scala
+++ b/src/main/scala/viper/silver/ast/Statement.scala
@@ -152,7 +152,13 @@ case class Apply(exp: MagicWand)(val pos: Position = NoPosition, val info: Info 
 }
 
 /** A sequence of statements. */
-case class Seqn(ss: Seq[Stmt], scopedDecls: Seq[Declaration])(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt with Scope
+case class Seqn(ss: Seq[Stmt], scopedSeqnDeclarations: Seq[Declaration])(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt with Scope {
+  /** scoped declarations of extended statements (contributed by plugins) as well as the declarations of the sequence itself */
+  override lazy val scopedDecls: Seq[Declaration] = scopedSeqnDeclarations ++ ss.flatMap {
+    case es: ExtensionStmt => es.declarationsInParentScope
+    case _ => Seq.empty
+  }
+}
 
 /** An if control statement. */
 case class If(cond: Exp, thn: Seqn, els: Seqn)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt {
@@ -205,4 +211,6 @@ case class LocalVarDeclStmt(decl: LocalVarDecl)(val pos: Position = NoPosition, 
 trait ExtensionStmt extends Stmt {
   def extensionSubnodes: Seq[Node]
   def prettyPrint: PrettyPrintPrimitives#Cont
+  /** declarations contributed by this statement that should be added to the parent scope */
+  def declarationsInParentScope: Seq[Declaration] = Seq.empty
 }

--- a/src/main/scala/viper/silver/ast/utility/Statements.scala
+++ b/src/main/scala/viper/silver/ast/utility/Statements.scala
@@ -55,9 +55,9 @@ object Statements {
       case QuantifiedExp(variables, _) =>
         // add quantified variables
         decls ++ variables
-      case Seqn(_, scoped) =>
+      case s: Seqn =>
         // add variables defined in scope
-        decls ++ scoped.collect { case variable: LocalVarDecl => variable }
+        decls ++ s.scopedDecls.collect { case variable: LocalVarDecl => variable }
       case _ =>
         decls
     }

--- a/src/main/scala/viper/silver/parser/Translator.scala
+++ b/src/main/scala/viper/silver/parser/Translator.scala
@@ -80,9 +80,9 @@ case class Translator(program: PProgram) {
 
       val newBody = body.map(actualBody => {
         val b = stmt(actualBody).asInstanceOf[Seqn]
-        val newScopedDecls = b.scopedDecls ++ b.deepCollect {case l: Label => l}
+        val newScopedDecls = b.scopedSeqnDeclarations ++ b.deepCollect {case l: Label => l}
 
-        b.copy(scopedDecls = newScopedDecls)(b.pos, b.info, b.errT)
+        b.copy(scopedSeqnDeclarations = newScopedDecls)(b.pos, b.info, b.errT)
       })
 
       val finalMethod = m.copy(pres = pres map exp, posts = posts map exp, body = newBody)(m.pos, m.info, m.errT)

--- a/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
@@ -138,6 +138,8 @@ trait ParserPluginTemplate {
     override def errT: ErrorTrafo = ???
     override def info: Info = ???
     override def prettyPrint: PrettyPrintPrimitives#Cont = ???
+    /** declarations contributed by this statement that should be added to the parent scope */
+    override def declarationsInParentScope: Seq[Declaration] = ???
   }
 
   /**


### PR DESCRIPTION
This PR enables plugins to contribute statements (as so called `ExtensionStmt`) that add declarations (e.g. local variables) to the parent scope in which the statement occurs.

For this purpose, `Seqn` has been extended to take a sequence of declarations (think of "regular" declarations) as parameter and add declarations contributed by extension statements.

While this solution might be less elegant than simply computing all declarations before instantiating a `Seqn` node, this solution makes it more convenient for frontends to use these extension statement as a frontend does not need to be aware of the internals of a plugin, in particular whether a certain extension statement expects certain declarations to be present