### PR TITLE
Created two versions of trigger generator to be used concurrently

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -9,7 +9,7 @@ package viper.silver.ast.utility
 import scala.reflect.ClassTag
 import viper.silver.ast._
 import viper.silver.ast.utility.rewriter.Traverse
-import viper.silver.ast.utility.Triggers.TriggerGeneration
+import viper.silver.ast.utility.Triggers.{DefaultTriggerGeneration, TriggerGeneration}
 import viper.silver.utility.Sanitizer
 
 /** Utility methods for expressions. */
@@ -266,17 +266,17 @@ object Expressions {
   }
 
   /** See [[viper.silver.ast.utility.Triggers.TriggerGeneration.generateTriggerSetGroups]] */
-  def generateTriggerGroups(exp: QuantifiedExp): Seq[(Seq[TriggerGeneration.TriggerSet], Seq[LocalVarDecl])] = {
-    TriggerGeneration.generateTriggerSetGroups(exp.variables map (_.localVar), exp.exp)
-                     .map{case (triggers, vars) => (triggers, vars map (v => LocalVarDecl(v.name, v.typ)()))}
+  def generateTriggerGroups(exp: QuantifiedExp, tg: TriggerGeneration = DefaultTriggerGeneration): Seq[(Seq[tg.TriggerSet], Seq[LocalVarDecl])] = {
+    tg.generateTriggerSetGroups(exp.variables map (_.localVar), exp.exp)
+      .map{case (triggers, vars) => (triggers, vars map (v => LocalVarDecl(v.name, v.typ)()))}
   }
 
   /** Returns the first group of trigger sets (together with newly introduced
     * variables) returned by [[Expressions.generateTriggerGroups]], or `None`
     * if the latter didn't return any group.
     */
-  def generateTriggerSet(exp: QuantifiedExp): Option[(Seq[LocalVarDecl], Seq[TriggerGeneration.TriggerSet])] = {
-    val gen = Expressions.generateTriggerGroups(exp)
+  def generateTriggerSet(exp: QuantifiedExp, tg: TriggerGeneration = DefaultTriggerGeneration): Option[(Seq[LocalVarDecl], Seq[tg.TriggerSet])] = {
+    val gen = Expressions.generateTriggerGroups(exp, tg)
 
     if (gen.nonEmpty)
       gen.find(pair => pair._2.isEmpty) match {

--- a/src/main/scala/viper/silver/ast/utility/GenericTriggerGenerator.scala
+++ b/src/main/scala/viper/silver/ast/utility/GenericTriggerGenerator.scala
@@ -6,6 +6,7 @@
 
 package viper.silver.ast.utility
 
+import java.util.concurrent.atomic.AtomicInteger
 import reflect.ClassTag
 
 object GenericTriggerGenerator {
@@ -16,6 +17,7 @@ object GenericTriggerGenerator {
   * filters for accepting/rejecting possible triggers can be changed
   * (see, e.g. [[GenericTriggerGenerator.setCustomIsForbiddenInTrigger]]).
   */
+
 abstract class GenericTriggerGenerator[Node <: AnyRef,
                                        Type <: AnyRef,
                                        Exp  <: Node : ClassTag,
@@ -62,7 +64,7 @@ abstract class GenericTriggerGenerator[Node <: AnyRef,
   protected var customIsForbiddenInTrigger: PartialFunction[Exp, Boolean] = PartialFunction.empty
   def setCustomIsForbiddenInTrigger(f: PartialFunction[Exp, Boolean]): Unit = { customIsForbiddenInTrigger = f }
 
-  private var nextUniqueId = 0
+  private val nextUniqueId = new AtomicInteger(0)
 
   def generateTriggerSetGroup(vs: Seq[Var], toSearch: Exp): Option[(Seq[TriggerSet], Seq[Var])] =
     generateTriggerSetGroups(vs: Seq[Var], toSearch: Exp).headOption
@@ -175,8 +177,7 @@ abstract class GenericTriggerGenerator[Node <: AnyRef,
          */
         val processedArgs = getArgs(possibleTrigger) map (pt => transform(pt) {
           case e: Exp if isForbiddenInTrigger(e) =>
-            val newV = Var("fresh__" + nextUniqueId, Exp_typ(e))
-            nextUniqueId += 1
+            val newV = Var("fresh__" + nextUniqueId.getAndIncrement(), Exp_typ(e))
             extraVars +:= newV
 
             newV

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -9,12 +9,12 @@ package viper.silver.ast.utility
 import viper.silver.ast
 import viper.silver.ast._
 
+import java.util.concurrent.atomic.AtomicInteger
+
 /** Utility methods for triggers */
 object Triggers {
-  /** Attention: The trigger generator is *not* thread-safe, because its super class
-    * [[GenericTriggerGenerator]] is not.
-    */
-  object TriggerGeneration extends GenericTriggerGenerator[Node, Type, Exp, LocalVar, QuantifiedExp] {
+
+  class TriggerGeneration extends GenericTriggerGenerator[Node, Type, Exp, LocalVar, QuantifiedExp] {
     protected def hasSubnode(root: Node, child: Node) = root.hasSubnode(child)
     protected def visit[A](root: Node)(f: PartialFunction[Node, A]) = root.visit(f)
     protected def deepCollect[A](root: Node)(f: PartialFunction[Node, A]) = root.deepCollect(f)
@@ -53,13 +53,23 @@ object Triggers {
     }
   }
 
-  /** Attention: The axiom rewriter is *not* thread-safe, because it makes use of the
-    * [[TriggerGeneration]], which is not thread-safe.
+  /**
+    * We offer two objects with different configurations.
+    * If several Viper instances are to be used concurrently, code *must not* call the setCustomIsForbiddenTrigger and
+    * setCustomIsPossibleTrigger methods on these objects.
     */
+  object DefaultTriggerGeneration extends TriggerGeneration
+
+  object TriggerGenerationWithAddAndSubtract extends TriggerGeneration {
+    customIsForbiddenInTrigger = {
+      case _: ast.Add | _: ast.Sub => false
+    }
+  }
+
   object AxiomRewriter extends GenericAxiomRewriter[Type, Exp, LocalVar, QuantifiedExp, EqCmp, And, Implies, Add, Sub,
                                                     Trigger] {
 
-    private var nextUniqueId = 0
+    private val nextUniqueId = new AtomicInteger(0)
 
     /*
      * Abstract members - type arguments
@@ -94,7 +104,7 @@ object Triggers {
     protected def Trigger(exps: Seq[Exp]) = ast.Trigger(exps)()
 
     /* True iff the given node is not allowed in triggers */
-    protected def isForbiddenInTrigger(e: Exp): Boolean = TriggerGeneration.isForbiddenInTrigger(e)
+    protected def isForbiddenInTrigger(e: Exp): Boolean = DefaultTriggerGeneration.isForbiddenInTrigger(e)
 
     /*
      * Abstract members - dependencies
@@ -103,8 +113,7 @@ object Triggers {
     protected val solver = SimpleArithmeticSolver
 
     protected def fresh(name: String, typ: Type) = {
-      nextUniqueId += 1
-      LocalVar(s"__rw_$name$nextUniqueId", typ)()
+      LocalVar(s"__rw_$name${nextUniqueId.incrementAndGet()}", typ)()
     }
 
     protected def log(message: String): Unit = {}


### PR DESCRIPTION
Trigger generation code contains global objects that contain mutable state, which causes issues when running multiple instances of Silicon in parallel. This PR creates two default objects with different settings that removes the need to mutate state for current Silicon (while retaining the option to do so for any code that may need it).