### PR TITLE
Fixes Pretty Printer

### DIFF
--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -481,7 +481,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     case typ: Type => showType(typ)
     case p: Program => showProgram(p)
     case m: Member => showMember(m)
-    case v: LocalVarDecl => showVar(v)
+    case v: AnyLocalVarDecl => showVar(v)
     case dm: DomainMember => showDomainMember(dm)
     case Trigger(exps) =>
       text("{") <+> ssep(exps map show, group(char (',') <> line)) <+> "}"


### PR DESCRIPTION
Unnamed local variable declarations occur e.g. in domain functions, where parameter names are optional.
Although part of the Viper AST, the pretty printer currently crashes when invoking `pretty` with such an AST node.
This PR addresses this issue, which fixes [Viper-IDE #343](https://github.com/viperproject/viper-ide/issues/343) because nodes are pretty printed while computing hashes for cacheing (although pretty printing only happens for logging purposes)