### PR TITLE
Carbon IgnoreFile annotation for cyclic-list.vpr

### DIFF
--- a/src/test/resources/all/chalice/cyclic-list.vpr
+++ b/src/test/resources/all/chalice/cyclic-list.vpr
@@ -1,6 +1,8 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+//:: IgnoreFile(/carbon/issue/272/)
+
 field value: Int
 field next: Ref
 
@@ -40,6 +42,5 @@ method test2(this: Ref)
   x.next := x
 
   //:: ExpectedOutput(application.precondition:insufficient.permission)
-  //:: MissingOutput(application.precondition:insufficient.permission, /Carbon/issue/272/)
   assert ((length(x)) == (length(x.next) + 1))
 }


### PR DESCRIPTION
As discussed in https://github.com/viperproject/carbon/issues/272#issuecomment-1214778594, the Test `cyclic-list.vpr` currently is not handled properly by Carbon. Since changes in Carbon that do not logically change its encoding affect the results for this test, the file is now ignored for Carbon until the Carbon issue https://github.com/viperproject/carbon/issues/272 is resolved.