### PR TITLE
[Plugin] Translation of Entity Verification Results

### DIFF
--- a/src/main/scala/viper/silver/plugin/PluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/PluginTemplate.scala
@@ -8,6 +8,7 @@ package viper.silver.plugin
 
 import viper.silver.ast.Program
 import viper.silver.parser.PProgram
+import viper.silver.reporter.Entity
 import viper.silver.verifier.{AbstractError, VerificationResult}
 
 // The aim of this file is just to give a skeleton implementation to copy for a particular plugin implementation.
@@ -52,6 +53,15 @@ class PluginTemplate extends SilverPlugin {
       * @return Modified AST
       */
     override def beforeVerify(input: Program) : Program = ???
+
+    /** Called after the verification of an entity. Error transformation should happen here.
+      * This will only be called if verification took place.
+      *
+      * @param entity Entity to which `input` belongs
+      * @param input Result of verification
+      * @return Modified result
+      */
+    override def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult = ???
 
     /** Called after the verification. Error transformation should happen here.
       * This will only be called if verification took place.

--- a/src/main/scala/viper/silver/plugin/PluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/PluginTemplate.scala
@@ -54,8 +54,9 @@ class PluginTemplate extends SilverPlugin {
       */
     override def beforeVerify(input: Program) : Program = ???
 
-    /** Called after the verification of an entity. Error transformation should happen here.
-      * This will only be called if verification took place.
+    /** Called after the verification of an entity, which is used to stream verification results to the IDE
+      * (which happens as soon as a member has been verified). Error transformation should happen here.
+      * This will only be called if verification of `entity` took place.
       *
       * @param entity Entity to which `input` belongs
       * @param input Result of verification

--- a/src/main/scala/viper/silver/plugin/PluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/PluginTemplate.scala
@@ -66,10 +66,11 @@ class PluginTemplate extends SilverPlugin {
     /** Called after the verification. Error transformation should happen here.
       * This will only be called if verification took place.
       *
+      * @param program Viper AST
       * @param input Result of verification
       * @return Modified result
       */
-    override def mapVerificationResult(input: VerificationResult): VerificationResult = ???
+    override def mapVerificationResult(program: Program, input: VerificationResult): VerificationResult = ???
 
     /** Called after the verification just before the result is printed. Will not be called in tests.
       * This will also be called even if verification did not take place (i.e. an error during parsing/translation occurred).

--- a/src/main/scala/viper/silver/plugin/SilverPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPlugin.scala
@@ -10,7 +10,7 @@ import ch.qos.logback.classic.Logger
 import viper.silver.ast.Program
 import viper.silver.frontend.SilFrontendConfig
 import viper.silver.parser.{FastParser, PProgram}
-import viper.silver.reporter.Reporter
+import viper.silver.reporter.{Entity, Reporter}
 import viper.silver.verifier.{AbstractError, VerificationResult}
 
 import scala.annotation.unused
@@ -73,6 +73,15 @@ trait SilverPlugin {
     * @return Modified AST
     */
   def beforeVerify(input: Program) : Program = input
+
+  /** Called after the verification of an entity. Error transformation should happen here.
+    * This will only be called if verification took place.
+    *
+    * @param entity Entity to which `input` belongs
+    * @param input Result of verification
+    * @return Modified result
+    */
+  def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult = input
 
   /** Called after the verification. Error transformation should happen here.
     * This will only be called if verification took place.

--- a/src/main/scala/viper/silver/plugin/SilverPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPlugin.scala
@@ -74,8 +74,9 @@ trait SilverPlugin {
     */
   def beforeVerify(input: Program) : Program = input
 
-  /** Called after the verification of an entity. Error transformation should happen here.
-    * This will only be called if verification took place.
+  /** Called after the verification of an entity, which is used to stream verification results to the IDE
+    * (which happens as soon as a member has been verified). Error transformation should happen here.
+    * This will only be called if verification of `entity` took place.
     *
     * @param entity Entity to which `input` belongs
     * @param input Result of verification

--- a/src/main/scala/viper/silver/plugin/SilverPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPlugin.scala
@@ -86,10 +86,11 @@ trait SilverPlugin {
   /** Called after the verification. Error transformation should happen here.
     * This will only be called if verification took place.
     *
+    * @param program Viper AST
     * @param input Result of verification
     * @return Modified result
     */
-  def mapVerificationResult(input: VerificationResult): VerificationResult = input
+  def mapVerificationResult(program: Program, input: VerificationResult): VerificationResult = input
 
   /** Called after the verification just before the result is printed. Will not be called in tests.
     * This will also be called even if verification did not take place (i.e. an error during parsing/translation occurred).

--- a/src/main/scala/viper/silver/plugin/SilverPluginManager.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPluginManager.scala
@@ -10,7 +10,7 @@ import ch.qos.logback.classic.Logger
 import viper.silver.ast._
 import viper.silver.frontend.SilFrontendConfig
 import viper.silver.parser.{FastParser, PProgram}
-import viper.silver.reporter.Reporter
+import viper.silver.reporter.{Entity, Reporter}
 import viper.silver.verifier.{AbstractError, VerificationResult}
 
 /** Manage the loaded plugins and execute them during the different hooks (see [[viper.silver.plugin.SilverPlugin]]).
@@ -53,6 +53,9 @@ class SilverPluginManager(val plugins: Seq[SilverPlugin]) {
 
   def beforeVerify(input: Program): Option[Program] =
     foldWithError(input)((inp, plugin) => plugin.beforeVerify(inp))
+
+  def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult =
+    plugins.foldLeft(input)((inp, plugin) => plugin.mapEntityVerificationResult(entity, inp))
 
   def mapVerificationResult(input: VerificationResult): VerificationResult =
     plugins.foldLeft(input)((inp, plugin) => plugin.mapVerificationResult(inp))

--- a/src/main/scala/viper/silver/plugin/SilverPluginManager.scala
+++ b/src/main/scala/viper/silver/plugin/SilverPluginManager.scala
@@ -57,8 +57,8 @@ class SilverPluginManager(val plugins: Seq[SilverPlugin]) {
   def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult =
     plugins.foldLeft(input)((inp, plugin) => plugin.mapEntityVerificationResult(entity, inp))
 
-  def mapVerificationResult(input: VerificationResult): VerificationResult =
-    plugins.foldLeft(input)((inp, plugin) => plugin.mapVerificationResult(inp))
+  def mapVerificationResult(program: Program, input: VerificationResult): VerificationResult =
+    plugins.foldLeft(input)((inp, plugin) => plugin.mapVerificationResult(program, inp))
 
   def beforeFinish(input: VerificationResult): VerificationResult =
     plugins.foldLeft(input)((inp, plugin) => plugin.beforeFinish(inp))

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
@@ -15,6 +15,7 @@ import viper.silver.verifier.{ConsistencyError, Failure, Success, VerificationRe
 import viper.silver.verifier.errors.PreconditionInAppFalse
 import fastparse._
 import viper.silver.parser.FastParserCompanion.whitespace
+import viper.silver.reporter.Entity
 
 import scala.annotation.unused
 import scala.collection.immutable.ListMap
@@ -95,10 +96,16 @@ class PredicateInstancePlugin(@unused reporter: viper.silver.reporter.Reporter,
     newProgram
   }
 
+  override def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult =
+    translateVerificationResult(input)
+
   /**
    * Initiate the error transformer for possibly predicate instances related errors
    */
-  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
+  override def mapVerificationResult(input: VerificationResult): VerificationResult =
+    translateVerificationResult(input)
+
+  private def translateVerificationResult(input: VerificationResult): VerificationResult = {
     input match {
       case Success => input
       case Failure(errors) =>

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
@@ -102,7 +102,7 @@ class PredicateInstancePlugin(@unused reporter: viper.silver.reporter.Reporter,
   /**
    * Initiate the error transformer for possibly predicate instances related errors
    */
-  override def mapVerificationResult(input: VerificationResult): VerificationResult =
+  override def mapVerificationResult(@unused program: Program, input: VerificationResult): VerificationResult =
     translateVerificationResult(input)
 
   private def translateVerificationResult(input: VerificationResult): VerificationResult = {

--- a/src/main/scala/viper/silver/plugin/standard/refute/RefuteASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/refute/RefuteASTExtension.scala
@@ -11,7 +11,7 @@ import viper.silver.ast.pretty.FastPrettyPrinter.{ContOps, text, toParenDoc}
 import viper.silver.ast.pretty.PrettyPrintPrimitives
 
 /** An `FailureExpectedInfo` info that tells us that this assert is a refute. */
-case object RefuteInfo extends FailureExpectedInfo
+case class RefuteInfo(refute: Refute) extends FailureExpectedInfo
 
 case class Refute(exp: Exp)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends ExtensionStmt {
   override lazy val prettyPrint: PrettyPrintPrimitives#Cont = text("refute") <+> toParenDoc(exp)

--- a/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
@@ -12,6 +12,7 @@ import viper.silver.ast._
 import viper.silver.parser.FastParserCompanion.whitespace
 import viper.silver.parser.FastParser
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
+import viper.silver.reporter.Entity
 import viper.silver.verifier._
 import viper.silver.verifier.errors.AssertFailed
 
@@ -28,6 +29,7 @@ class RefutePlugin(@unused reporter: viper.silver.reporter.Reporter,
   private val refuteKeyword: String = "refute"
 
   private var refuteAsserts: Map[Position, Refute] = Map()
+  private var refuteAssertsPerEntity: Map[(Method, Position), Refute] = Map()
 
   /** Parser for refute statements. */
   def refute[_: P]: P[PRefute] =
@@ -46,40 +48,74 @@ class RefutePlugin(@unused reporter: viper.silver.reporter.Reporter,
    * Remove refute statements from the AST and add them as non-det asserts.
    * The ⭐ is nice since such a variable name cannot be parsed, but will it cause issues?
    */
-  override def beforeVerify(input: Program): Program =
-    ViperStrategy.Slim({
-      case r@Refute(exp) => {
-        this.refuteAsserts += (r.pos -> r)
-        Seqn(Seq(
-          If(LocalVar(s"__plugin_refute_nondet${this.refuteAsserts.size}", Bool)(r.pos),
-            Seqn(Seq(
-              Assert(exp)(r.pos, RefuteInfo),
-              Inhale(BoolLit(false)(r.pos))(r.pos)
-            ), Seq())(r.pos),
-            Seqn(Seq(), Seq())(r.pos))(r.pos)
-          ),
-          Seq(LocalVarDecl(s"__plugin_refute_nondet${this.refuteAsserts.size}", Bool)(r.pos))
-        )(r.pos)
-      }
-    }).recurseFunc({
-      case Method(_, _, _, _, _, body) => Seq(body)
-    }).execute(input)
-
-  /** Remove refutation related errors and add refuteAsserts that didn't report an error. */
-  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
-    val errors: Seq[AbstractError] = (input match {
-      case Success => Seq()
-      case Failure(errors) => {
-        errors.filter {
-          case AssertFailed(a, _, _) if a.info == RefuteInfo => {
-            this.refuteAsserts -= a.pos
-            false
+  override def beforeVerify(input: Program): Program = {
+    val transformedMethods = input.methods.map(method =>
+      ViperStrategy.Slim({
+        case r@Refute(exp) =>
+          this.refuteAsserts += (r.pos -> r)
+          this.refuteAssertsPerEntity += ((method, r.pos) -> r)
+          val refutesInMethod = this.refuteAssertsPerEntity.count {
+            case ((m, _), _) => method == m
           }
+          val nonDetLocalVarDecl = LocalVarDecl(s"__plugin_refute_nondet$refutesInMethod", Bool)(r.pos)
+          Seqn(Seq(
+            If(nonDetLocalVarDecl.localVar,
+              Seqn(Seq(
+                Assert(exp)(r.pos, RefuteInfo),
+                Inhale(BoolLit(false)(r.pos))(r.pos)
+              ), Seq())(r.pos),
+              Seqn(Seq(), Seq())(r.pos))(r.pos)
+          ),
+            Seq(nonDetLocalVarDecl)
+          )(r.pos)
+      }).recurseFunc({
+        case Method(_, _, _, _, _, body) => Seq(body)
+      }).execute[Method](method))
+    Program(input.domains, input.fields, input.functions, input.predicates, transformedMethods, input.extensions)(input.pos, input.info, input.errT)
+  }
+
+  /** Remove refutation related errors for the current entity and add refuteAsserts in this entity that didn't report an error. */
+  override def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult = {
+    val occurredNonRefuteErrors = input match {
+      case Success => Seq()
+      case Failure(errors) =>
+        errors.filter {
+          case AssertFailed(a, _, _) if a.info == RefuteInfo =>
+            // remove entries whose method and position match:
+            this.refuteAssertsPerEntity = this.refuteAssertsPerEntity.filter {
+              case ((m, pos), _) if entity == m && a.pos == pos => false
+              case _ => true
+            }
+            false
           case _ => true
         }
-      }
-    }) ++ this.refuteAsserts.map(r => RefuteFailed(r._2, RefutationTrue(r._2.exp)))
-    if (errors.length == 0) Success
+    }
+    val missingErrorsInEntity = this.refuteAssertsPerEntity.flatMap {
+      case ((m, _), refute) if entity == m => Some(RefuteFailed(refute, RefutationTrue(refute.exp)))
+      case _ => None
+    }
+    val errors = occurredNonRefuteErrors ++ missingErrorsInEntity
+    if (errors.isEmpty) Success
+    else Failure(errors)
+  }
+
+  /** Remove refutation related errors (for all entities) and add refuteAsserts (for all entities) that didn't report an error. */
+  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
+    val occurredNonRefuteErrors = input match {
+      case Success => Seq()
+      case Failure(errors) =>
+        errors.filter {
+          case AssertFailed(a, _, _) if a.info == RefuteInfo =>
+            this.refuteAsserts -= a.pos
+            false
+          case _ => true
+        }
+    }
+    val missingErrorsInEntity = this.refuteAsserts.map {
+      case (_, refute) => RefuteFailed(refute, RefutationTrue(refute.exp))
+    }
+    val errors = occurredNonRefuteErrors ++ missingErrorsInEntity
+    if (errors.isEmpty) Success
     else Failure(errors)
   }
 }

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -128,7 +128,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
   /**
     * Call the error transformation on possibly termination related errors.
     */
-  override def mapVerificationResult(input: VerificationResult): VerificationResult =
+  override def mapVerificationResult(@unused program: Program, input: VerificationResult): VerificationResult =
     translateVerificationResult(input)
 
   private def translateVerificationResult(input: VerificationResult): VerificationResult = {

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -13,10 +13,11 @@ import viper.silver.parser._
 import viper.silver.plugin.standard.predicateinstance.PPredicateInstance
 import viper.silver.plugin.standard.termination.transformation.Trafo
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
-import viper.silver.verifier.errors.AssertFailed
+import viper.silver.verifier.errors.{AssertFailed, PreconditionInAppFalse}
 import viper.silver.verifier._
 import fastparse._
 import viper.silver.parser.FastParserCompanion.whitespace
+import viper.silver.reporter.Entity
 
 import scala.annotation.unused
 
@@ -121,10 +122,16 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
     }
   }
 
+  override def mapEntityVerificationResult(entity: Entity, input: VerificationResult): VerificationResult =
+    translateVerificationResult(input)
+
   /**
-   * Call the error transformation on possibly termination related errors.
-   */
-  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
+    * Call the error transformation on possibly termination related errors.
+    */
+  override def mapVerificationResult(input: VerificationResult): VerificationResult =
+    translateVerificationResult(input)
+
+  private def translateVerificationResult(input: VerificationResult): VerificationResult = {
     if (deactivated) return input // if decreases checks are deactivated no verification result mapping is required.
 
     input match {

--- a/src/test/scala/AstPositionsTests.scala
+++ b/src/test/scala/AstPositionsTests.scala
@@ -111,44 +111,37 @@ class AstPositionsTests extends AnyFunSuite {
         fail("method posts must have start and end positions set")
     }
     // Check position of body
-    if (m.body.get.ss.length == 1) {
-      val block: Stmt = m.body.get.ss(0)
-      block.pos match {
-        case spos: AbstractSourcePosition => {
-          assert(spos.start.line === 5 && spos.end.get.line === 10)
-          assert(spos.start.column === 1 && spos.end.get.column === 2)
-        }
-        case _ =>
-          fail("statements must have start and end positions set")
+    val block = m.body.get
+    block.pos match {
+      case spos: AbstractSourcePosition => {
+        assert(spos.start.line === 5 && spos.end.get.line === 10)
+        assert(spos.start.column === 1 && spos.end.get.column === 2)
       }
-      if (block.isInstanceOf[Seqn]) {
-        // Check position of forall
-        assert(block.asInstanceOf[Seqn].ss.length === 4)
-        val forall: Stmt = block.asInstanceOf[Seqn].ss(0)
-        forall.pos match {
-          case spos: AbstractSourcePosition => {
-            assert(spos.start.line === 6 && spos.end.get.line === 6)
-            assert(spos.start.column === 3 && spos.end.get.column === 48)
-          }
-          case _ =>
-            fail("forall must have start and end positions set")
-        };
-        // Check position of assert
-        val assert_exp: Exp = block.asInstanceOf[Seqn].ss(1).asInstanceOf[Assert].exp
-        assert_exp.pos match {
-          case spos: AbstractSourcePosition => {
-            assert(spos.start.line === 7 && spos.end.get.line === 7)
-            assert(spos.start.column === 10 && spos.end.get.column === 20)
-          }
-          case _ =>
-            fail("forall must have start and end positions set")
-        }
-      } else {
-        fail("Failed to check position of statements in method body due to layout change")
-      }
-    } else {
-      fail("Failed to check position of statements in method body due to layout change")
+      case _ =>
+        fail("statements must have start and end positions set")
     }
+    // Check position of forall
+    assert(block.ss.length === 4)
+    val forall: Stmt = block.ss(0)
+    forall.pos match {
+      case spos: AbstractSourcePosition => {
+        assert(spos.start.line === 6 && spos.end.get.line === 6)
+        assert(spos.start.column === 3 && spos.end.get.column === 48)
+      }
+      case _ =>
+        fail("forall must have start and end positions set")
+    };
+    // Check position of assert
+    val assert_exp: Exp = block.ss(1).asInstanceOf[Assert].exp
+    assert_exp.pos match {
+      case spos: AbstractSourcePosition => {
+        assert(spos.start.line === 7 && spos.end.get.line === 7)
+        assert(spos.start.column === 10 && spos.end.get.column === 20)
+      }
+      case _ =>
+        fail("forall must have start and end positions set")
+    }
+
     // Check position of second method
     val m2: Method = res.methods(1);
     m2.pos match {

--- a/src/test/scala/PluginTests.scala
+++ b/src/test/scala/PluginTests.scala
@@ -5,7 +5,6 @@
 // Copyright (c) 2011-2021 ETH Zurich.
 
 import java.nio.file.Paths
-
 import org.scalatest.funsuite.AnyFunSuite
 import viper.silver.ast.{LocalVar, Perm, Program}
 import viper.silver.frontend.{SilFrontend, SilFrontendConfig}
@@ -16,6 +15,8 @@ import viper.silver.verifier.errors.Internal
 import viper.silver.verifier.reasons.FeatureUnsupported
 import viper.silver.verifier._
 import viper.silver.ast.NoPosition
+
+import scala.annotation.unused
 
 trait TestPlugin {
   def test(): Boolean = true
@@ -148,7 +149,7 @@ class TestPluginMapErrors extends SilverPlugin with TestPlugin with FakeResult {
   var error2: Internal = Internal(FeatureUnsupported(LocalVar("test2", Perm)(), "Test2"))
   var finish = false
 
-  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
+  override def mapVerificationResult(@unused program: Program, input: VerificationResult): VerificationResult = {
     input match {
       case Success =>
 //        println(">>> detected VerificationResult is Success")
@@ -197,7 +198,7 @@ class TestPluginMapVsFinish extends SilverPlugin with TestPlugin {
     input
   }
 
-  override def mapVerificationResult(input: VerificationResult): VerificationResult = {
+  override def mapVerificationResult(@unused program: Program, input: VerificationResult): VerificationResult = {
     assert(!finish)
     input
   }


### PR DESCRIPTION
This PR adds another hook to the plugin infrastructure such that plugins can translation entity verification results.
For most plugins, the translation in this step is supposed to be identical to translating the overall verification result (which is the case for the current set of plugins).

The refute plugin has been adapted to (1) be aware of refute statements per entity (and thus support streaming of verification results) and (2) be stateless. The latter is achieved by storing all necessary information in the AST (as Info) instead of in the plugin's state. For this purpose, `mapVerificationResult` takes now the AST (as produced after applying all plugins' `beforeVerify`) as parameter such that plugins do not need to store the AST.

Furthermore, this PR changes `SilFrontend` to apply filtering of methods (based on the configuration) and to apply all plugins' `beforeVerify` at the beginning of the verification phase (instead of at the end of the consistency check phase). This is irrelevant for instances of `SilFrontend` that execute both, the consistency check phase followed by the verification phase. However, `ViperAstProvider` is an instance that only performs the phases up to including consistency checking (i.e. without verifying the resulting AST).
This change has two purposes:
1. It's imho more sensible to perform `beforeVerify` before verifying an AST.
2. ViperServer splits the overall process into two steps: (1) generating an AST (by using `ViperAstProvider`) and (2) verifying an AST (by using SiliconFrontend, CarbonFrontend or a custom frontend in an abusive way such that the enclosed verifier is used without executing all phases). This change moves the application of `beforeVerify` to ViperServer's second step, which not only gives the second step more flexibility to decide when exactly to apply `beforeVerify` (i.e. before or after applying the cache) but also provides flexibility to plugin implementations as their state is maintained between `beforeVerify` and `mapVerificationResult` (this was not the case in the past because separate instances of the plugin are used by the two ViperServer steps (which however remains the case)).

The latter change made the changes to `AstPositionsTests` necessary because the resulting AST (produced by `ViperAstProvider`) now looks apparently different (imho better / as one would expect).

Fixes #634 