### PR TITLE
Added consistency check for domain and backend types

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -31,7 +31,7 @@ case class Program(domains: Seq[Domain], fields: Seq[Field], functions: Seq[Func
     }).distinct
 
   override lazy val check : Seq[ConsistencyError] =
-    Consistency.checkContextDependentConsistency(this) ++
+    Consistency.checkContextDependentConsistency(this, this) ++
     Consistency.checkNoFunctionRecursesViaPreconditions(this) ++
     checkMethodCallsAreValid ++
     checkFunctionApplicationsAreValid ++

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -364,6 +364,7 @@ object Consistency {
           case Some(domain) if domain.interpretations.isDefined =>
             s :+= ConsistencyError(s"DomainType ${dt.domainName} references domain with interpretation; must use BackendType instead.", NoPosition)
             c
+          case _ => c
         }
 
       case bt: BackendType =>
@@ -377,6 +378,7 @@ object Consistency {
           case Some(domain) if domain.interpretations.get != bt.interpretations =>
             s :+= ConsistencyError(s"BackendType ${bt.viperName} has different interpretations than the domain it references.", NoPosition)
             c
+          case _ => c
         }
 
     })


### PR DESCRIPTION
Adding consistency checks that

- check, for every DomainType and BackendType, that the domain they refer to actually exists
- check, for every DomainType, that it refers to a domain without an interpretation
- check, for every BackendType, that it refers to a domain with an interpretation, and that the interpretations match between the Type and the domain itself.