### PR TITLE
Fix Termination Measures in Methods' Postconditions

### DIFF
--- a/src/test/resources/termination/functions/basic/specOrder.vpr
+++ b/src/test/resources/termination/functions/basic/specOrder.vpr
@@ -1,0 +1,68 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/int.vpr>
+
+// Viper permits writing decreases measures anywhere in a function's specification
+// and this test case checks that the transformations correctly account for this
+
+function fun1(x: Int): Int
+  decreases
+  requires true
+  ensures  true
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  x > -10 ? fun1(x-1) : 6
+}
+
+function fun2(x: Int): Int
+  requires true
+  decreases
+  ensures  true
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  x > -10 ? fun2(x-1) : 6
+}
+
+function fun3(x: Int): Int
+  requires true
+  ensures  true
+  decreases
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  x > -10 ? fun3(x-1) : 6
+}
+
+
+// the following methods check that the termination plugin considers ALL stated termination measures independently of
+// how they are mixed with pre- and postconditions
+
+function fun4(x: Int): Int
+  decreases _ if x <= -10
+  decreases x+10 if x > -10 // verification of this function does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+  requires true
+  ensures  true
+{
+  //:: ExpectedOutput(termination.failed:tuple.condition.false)
+  x > -10 ? fun4(x-1) : 6
+}
+
+function fun5(x: Int): Int
+  decreases _ if x <= -10
+  requires true
+  decreases x+10 if x > -10 // verification of this function does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+  ensures  true
+{
+  //:: ExpectedOutput(termination.failed:tuple.condition.false)
+  x > -10 ? fun5(x-1) : 6
+}
+
+function fun6(x: Int): Int
+  decreases _ if x <= -10
+  requires true
+  ensures  true
+  decreases x+10 if x > -10 // verification of this function does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+{
+  //:: ExpectedOutput(termination.failed:tuple.condition.false)
+  x > -10 ? fun6(x-1) : 6
+}

--- a/src/test/resources/termination/methods/basic/specOrder.vpr
+++ b/src/test/resources/termination/methods/basic/specOrder.vpr
@@ -1,0 +1,92 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/int.vpr>
+
+// Viper permits writing decreases measures anywhere in a method's specification
+// and this test case checks that the transformations correctly account for this
+
+method m1(x:Int, y:Int) returns (res: Int)
+  decreases
+  requires x>0 && y>0
+  ensures  true
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    res := m1(y, y)
+  }
+}
+
+method m2(x:Int, y:Int) returns (res: Int)
+  requires x>0 && y>0
+  decreases
+  ensures  true
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    res := m2(y, y)
+  }
+}
+
+method m3(x:Int, y:Int) returns (res: Int)
+  requires x>0 && y>0
+  ensures  true
+  decreases
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    res := m3(y, y)
+  }
+}
+
+
+// the following methods check that the termination plugin considers ALL stated termination measures independently of
+// how they are mixed with pre- and postconditions
+
+method m4(x:Int, y:Int) returns (res: Int)
+  decreases _ if y >= x
+  decreases x if y < x // verification of this method does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+  requires x>0 && y>0
+  ensures  true
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.condition.false)
+    res := m4(y, y)
+  }
+}
+
+method m5(x:Int, y:Int) returns (res: Int)
+  decreases _ if y >= x
+  requires x>0 && y>0
+  decreases x if y < x // verification of this method does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+  ensures  true
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.condition.false)
+    res := m5(y, y)
+  }
+}
+
+method m6(x:Int, y:Int) returns (res: Int)
+  decreases _ if y >= x
+  requires x>0 && y>0
+  ensures  true
+  decreases x if y < x // verification of this method does not result in a verification failure in case this termination measure is ignored / dropped by the plugin
+{
+  if (y >= x) {
+    res := 8
+  } else {
+    //:: ExpectedOutput(termination.failed:tuple.condition.false)
+    res := m6(y, y)
+  }
+}


### PR DESCRIPTION
While the termination plugin extends the parser to allow termination measures anywhere in a function's or method's specification (i.e. before and after pre- and postconditions), the termination plugin did not correctly handle the case in which a method's postcondition contains termination measures.

This PR applies the same logic as used for function specs to methods, i.e. remove termination measures in pre- and postconditions and turn them into info annotations.