### PR TITLE
Change simplification for conditionals to use implications instead of disjunctions

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -79,7 +79,11 @@ object Simplifier {
       case root @ CondExp(condition, FalseLit(), ifFalse) =>
         And(Not(condition)(), ifFalse)(root.pos, root.info)
       case root @ CondExp(condition, TrueLit(), ifFalse) =>
-        Implies(Not(condition)(), ifFalse)(root.pos, root.info)
+        if(ifFalse.isPure) {
+          Or(condition, ifFalse)(root.pos, root.info)
+        } else {
+          Implies(Not(condition)(), ifFalse)(root.pos, root.info)
+        }
       case root @ CondExp(condition, ifTrue, FalseLit()) =>
         And(condition, ifTrue)(root.pos, root.info)
       case root @ CondExp(condition, ifTrue, TrueLit()) =>

--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -79,11 +79,11 @@ object Simplifier {
       case root @ CondExp(condition, FalseLit(), ifFalse) =>
         And(Not(condition)(), ifFalse)(root.pos, root.info)
       case root @ CondExp(condition, TrueLit(), ifFalse) =>
-        Or(condition, ifFalse)(root.pos, root.info)
+        Implies(Not(condition)(), ifFalse)(root.pos, root.info)
       case root @ CondExp(condition, ifTrue, FalseLit()) =>
         And(condition, ifTrue)(root.pos, root.info)
       case root @ CondExp(condition, ifTrue, TrueLit()) =>
-        Or(Not(condition)(), ifTrue)(root.pos, root.info)
+        Implies(condition, ifTrue)(root.pos, root.info)
 
       case root @ Forall(_, _, BoolLit(literal)) =>
         BoolLit(literal)(root.pos, root.info)

--- a/src/test/scala/SimplifierTests.scala
+++ b/src/test/scala/SimplifierTests.scala
@@ -17,9 +17,18 @@ class SimplifierTests extends AnyFunSuite with Matchers {
 
     val a = LocalVar("a", Bool)()
     val b = LocalVar("a", Bool)()
+    val acc = PredicateAccessPredicate(
+      PredicateAccess(Nil, "pred")(),
+      FullPerm()()
+    )()
     val tru = TrueLit()()
 
-    simplify(CondExp(a,tru,b)()) should be(Implies(Not(a)(), b)())
+    // Non-pure conditional should be converted into implication
+    simplify(CondExp(a,tru,acc)()) should be(Implies(Not(a)(), acc)())
+
+    // Pure conditional can be converted into disjunction
+    simplify(CondExp(a,tru,b)()) should be(Or(a, b)())
+
     simplify(CondExp(a,b,tru)()) should be(Implies(a, b)())
 
   }

--- a/src/test/scala/SimplifierTests.scala
+++ b/src/test/scala/SimplifierTests.scala
@@ -12,6 +12,18 @@ import viper.silver.ast._
 import viper.silver.ast.utility.Simplifier._
 
 class SimplifierTests extends AnyFunSuite with Matchers {
+
+  test("cond") {
+
+    val a = LocalVar("a", Bool)()
+    val b = LocalVar("a", Bool)()
+    val tru = TrueLit()()
+
+    simplify(CondExp(a,tru,b)()) should be(Implies(Not(a)(), b)())
+    simplify(CondExp(a,b,tru)()) should be(Implies(a, b)())
+
+  }
+
   test("div") {
     simplify(Div(0, 0)()) should be(Div(0, 0)())
     simplify(Div(8, 2)()) should be(4: IntLit)


### PR DESCRIPTION
Non-pure expressions (i.e. `acc(...)`) are not allowed in disjunctions. However the simplifier's current handling of conditionals has two cases where a conditional may be converted into a disjunction, thus possibly breaking the well-formedness of some expressions.

This PR changes the behaviour as follows:

1. Expressions of the form `a ? true : b`, where `b` is not pure, are simplified to `!a ==> b` 
2. Expressions of the form `a ? b : true` are simplified to `a ==> b` (the current implementation simplifies such expressions to `(!a || b)`)