### PR TITLE
Copying info and errT metadata to negated branch condition nodes

### DIFF
--- a/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
+++ b/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
@@ -363,7 +363,7 @@ object CfgGenerator {
             current = None
           case ConditionalJumpStmt(cond, thnTarget, elsTarget) =>
             current.foreach { currentIndex =>
-              val neg = Not(cond)(cond.pos)
+              val neg = Not(cond)(cond.pos, cond.info, cond.errT)
               addTmpEdge(TmpConditionalEdge(cond, currentIndex, resolve(thnTarget)))
               addTmpEdge(TmpConditionalEdge(neg, currentIndex, resolve(elsTarget)))
             }


### PR DESCRIPTION
When creating the CFG from an AST (e.g. for use in Silicon), Viper creates conditional edges with negated conditions, for example for else-branches of conditionals. These are newly-created AST nodes, and they did not get any info or error transformer attached. Since these nodes can appear to users/frontends as the offending nodes (e.g. for IfFailed errors), this can lead to frontends getting an offending node without any metadata (see Gobra issue [45](https://github.com/viperproject/gobra/issues/45)) they would normally expect.
This PR copies the metadata from the actual condition node to the newly-created negated condition node.