### PR TITLE
Update compiler to 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@
 // Settings common to Silver and backends
 // Compilation settings
 
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq(
   "-encoding", "UTF-8",               // Enforce UTF-8, instead of relying on properly set locales
   "-deprecation",                     // Warn when using deprecated language features


### PR DESCRIPTION
To avoid conflicts, you may need to delete your `target` folders before re-compiling the viper tools