### PR TITLE
Avoid linear lookups in a Program

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -357,7 +357,7 @@ object Consistency {
         c
 
       case dt: DomainType =>
-        c.program.domains.find(_.name == dt.domainName) match {
+        c.program.findDomainOptionally(dt.domainName) match {
           case None =>
             s :+= ConsistencyError(s"DomainType references non-existent domain ${dt.domainName}.", NoPosition)
             c
@@ -368,7 +368,7 @@ object Consistency {
         }
 
       case bt: BackendType =>
-        c.program.domains.find(_.name == bt.viperName) match {
+        c.program.findDomainOptionally(bt.viperName) match {
           case None =>
             s :+= ConsistencyError(s"BackendType references non-existent domain ${bt.viperName}.", NoPosition)
             c

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
@@ -58,7 +58,7 @@ class PredicateInstancePlugin(@unused reporter: viper.silver.reporter.Reporter,
    * (to the respective predicate instance functions)
    */
   override def beforeVerify(input: Program): Program = {
-    val PredicateInstanceDomain: Option[Domain] =  input.domains.find(_.name == "PredicateInstance")
+    val PredicateInstanceDomain: Option[Domain] =  input.findDomainOptionally("PredicateInstance")
 
     // list of all created predicate instance functions
     var createdPIFunctions = ListMap[String, Function]()

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
@@ -19,7 +19,7 @@ import viper.silver.verifier.errors.AssertFailed
 trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicates with ErrorReporter {
 
   private def getMethodDecreasesSpecification(method: String): DecreasesSpecification = {
-    program.methods.find(_.name == method) match {
+    program.findMethodOptionally(method) match {
       case Some(f) => DecreasesSpecification.fromNode(f)
       case None => DecreasesSpecification()
     }


### PR DESCRIPTION
This PR introduces several lazy maps that index the program items by name.

Fixes #657.