### PR TITLE
Updating tests

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -45,12 +45,16 @@ object Triggers {
     protected def withArgs(e: Exp, args: Seq[Exp]): Exp = e match {
       case pt: PossibleTrigger => pt.withArgs(args)
       case fa: FieldAccess => fa.withArgs(args)
+      case o@Old(pt: PossibleTrigger) => Old(pt.withArgs(args))(o.pos, o.info, o.errT)
+      case o@LabelledOld(pt: PossibleTrigger, lbl) => LabelledOld(pt.withArgs(args), lbl)(o.pos, o.info, o.errT)
       case _ => sys.error(s"Unexpected expression $e")
     }
 
     protected def getArgs(e: Exp): Seq[Exp] = e match {
       case pt: PossibleTrigger => pt.getArgs
       case fa: FieldAccess => fa.getArgs
+      case Old(pt: PossibleTrigger) => pt.getArgs
+      case LabelledOld(pt: PossibleTrigger, _) => pt.getArgs
       case _ => sys.error(s"Unexpected expression $e")
     }
   }

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -30,6 +30,8 @@ object Triggers {
     /* True iff the given node is a possible trigger */
     protected def isPossibleTrigger(e: Exp): Boolean = (customIsPossibleTrigger orElse {
       case _: PossibleTrigger => true
+      case Old(_: PossibleTrigger) => true
+      case LabelledOld(_: PossibleTrigger, _) => true
       case _ => false
     }: PartialFunction[Exp, Boolean])(e)
 

--- a/src/test/resources/all/issues/silicon/0509.vpr
+++ b/src/test/resources/all/issues/silicon/0509.vpr
@@ -40,6 +40,5 @@ method merge_sort_part(arr: Ref, from: Int, until: Int)
   //assert index < right_index // sanity check: passes
   store(arr,index, left_value);
 
-  //:: UnexpectedOutput(assert.failed:assertion.false, /silicon/issue/509/)
   assert forall i:Int, j:Int :: {lookup(arr,i),lookup(arr,j)}(right_index<=i && i<j && j<until) ==> lookup(arr,i) <= lookup(arr,j)
 }

--- a/src/test/resources/examples/quickselect/arrays_quickselect_rec.vpr
+++ b/src/test/resources/examples/quickselect/arrays_quickselect_rec.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/280/)
 
 /* https://en.wikipedia.org/wiki/Quickselect
  *
@@ -38,7 +37,7 @@ method swap(a: IArray, i: Int, j: Int)
  * axiom again, causing a matching loop.
  */
 define permuted(a, left, right, pw)
-  forall i: Int :: {pw[i]} left <= i && i <= right ==> loc(a, i).val == old(loc(a, pw[i]).val)
+  forall i: Int :: {old(pw[i])} left <= i && i <= right ==> loc(a, i).val == old(loc(a, pw[i]).val)
 
 method partition(a: IArray, left: Int, right: Int, pivotIndex: Int) returns (storeIndex: Int, pw: Seq[Int])
   /* All indices are valid and their relative order is satisfied */

--- a/src/test/resources/examples/quickselect/arrays_quickselect_rec_index-shifting.vpr
+++ b/src/test/resources/examples/quickselect/arrays_quickselect_rec_index-shifting.vpr
@@ -41,7 +41,7 @@ method swap(a: IArray, i: Int, j: Int)
  * to trigger the axiom again, causing a matching loop.
  */
 define permuted(a, left, pw)
-  forall i: Int :: {pw[i]} 0 <= i && i < |pw| ==> loc(a, left + i).val == old(loc(a, pw[i]).val)
+  forall i: Int :: {old(pw[i])} 0 <= i && i < |pw| ==> loc(a, left + i).val == old(loc(a, pw[i]).val)
 
 method partition(a: IArray, left: Int, right: Int, pivotIndex: Int) returns (storeIndex: Int, pw: Seq[Int])
   /* All indices are valid and their relative order is satisfied */

--- a/src/test/resources/examples/vmcai2016/arraylist-quantified-permissions.vpr
+++ b/src/test/resources/examples/vmcai2016/arraylist-quantified-permissions.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/280/)
 
 domain Pair[T1,T2] {
   function first(p : Pair[T1,T2]): T1
@@ -109,7 +108,7 @@ method insert(this: Ref, elem: Int) returns (j: Int)
     invariant 0 <= j && j <= length(this)
     invariant j > 0 ==> itemAt(this,j-1) <= elem
     invariant length(this) == old(length(this))
-    invariant forall k: Int :: {itemAt(this,k)} 0 <= k && k < length(this) ==> itemAt(this,k) == old(itemAt(this,k))
+    invariant forall k: Int :: {old(itemAt(this,k))} 0 <= k && k < length(this) ==> itemAt(this,k) == old(itemAt(this,k))
   {
     unfold acc(AList(this))
     j := j + 1


### PR DESCRIPTION
- Removing expected error in anticipation of fixing Silicon issue 509
- Fixing some triggers in tests that do not terminate in current Carbon and fixed Silicon
- Re-enabling those tests for Carbon
- old-expressions should be possible triggers