### PR TITLE
Consistency check to forbid empty ADTs.

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -26,6 +26,13 @@ case class Adt(name: String, constructors: Seq[AdtConstructor], typVars: Seq[Typ
 
   override def extensionSubnodes: Seq[Node] = constructors ++ typVars ++ derivingInfo.map(_._2._1).collect { case Some(v) => v }
 
+  override lazy val check: Seq[ConsistencyError] = {
+    if (constructors.isEmpty)
+      Seq(ConsistencyError( s"ADT $name must have at least one constructor.", pos))
+    else
+      Seq()
+  }
+
   override def prettyPrint: PrettyPrintPrimitives#Cont = {
 
     def showDerivingInfo(di: (String, (Option[Type], Set[String]))): PrettyPrintPrimitives#Cont = {

--- a/src/test/resources/all/issues/silver/0693.vpr
+++ b/src/test/resources/all/issues/silver/0693.vpr
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+//:: ExpectedOutput(consistency.error)
+adt Test {}
+
+method foo() {
+  refute false
+}


### PR DESCRIPTION
Fixes issue #693.
Forbidding empty ADTs seems like the right thing to do.