### PR TITLE
Adding consistency check to forbid wildcards in compound expressions

### DIFF
--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -286,14 +286,14 @@ object AccessPredicate {
 /** An accessibility predicate for a field location. */
 case class FieldAccessPredicate(loc: FieldAccess, perm: Exp)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends AccessPredicate {
   override lazy val check : Seq[ConsistencyError] =
-    if(!(perm isSubtype Perm)) Seq(ConsistencyError(s"Permission amount parameter of access predicate must be of Perm type, but found ${perm.typ}", perm.pos)) else Seq()
+    (if(!(perm isSubtype Perm)) Seq(ConsistencyError(s"Permission amount parameter of access predicate must be of Perm type, but found ${perm.typ}", perm.pos)) else Seq()) ++ Consistency.checkWildcardUsage(perm)
   val typ: Bool.type = Bool
 }
 
 /** An accessibility predicate for a predicate location. */
 case class PredicateAccessPredicate(loc: PredicateAccess, perm: Exp)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends AccessPredicate {
   override lazy val check : Seq[ConsistencyError] =
-    if(!(perm isSubtype Perm)) Seq(ConsistencyError(s"Permission amount parameter of access predicate must be of Perm type, but found ${perm.typ}", perm.pos)) else Seq()
+    (if(!(perm isSubtype Perm)) Seq(ConsistencyError(s"Permission amount parameter of access predicate must be of Perm type, but found ${perm.typ}", perm.pos)) else Seq()) ++ Consistency.checkWildcardUsage(perm)
   val typ: Bool.type = Bool
 }
 

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -196,6 +196,20 @@ object Consistency {
     (if(!noLabelledOld(e)) Seq(ConsistencyError("Labelled-old expressions are not allowed in postconditions.", e.pos)) else Seq())
   }
 
+  def checkWildcardUsage(e: Exp): Seq[ConsistencyError] = {
+    val containedWildcards = e.shallowCollect{
+      case w: WildcardPerm => w
+    }
+    if (containedWildcards.nonEmpty) {
+      e match {
+        case _: WildcardPerm => Seq()
+        case _ => Seq(ConsistencyError("Wildcard occurs inside compound expression (should only occur directly in an accessibility predicate).", e.pos))
+      }
+    } else {
+      Seq()
+    }
+  }
+
   /** checks that all quantified variables appear in all triggers */
   def checkAllVarsMentionedInTriggers(variables: Seq[LocalVarDecl], triggers: Seq[Trigger]) : Seq[ConsistencyError] = {
     var s = Seq.empty[ConsistencyError]

--- a/src/test/resources/all/issues/silver/0534.vpr
+++ b/src/test/resources/all/issues/silver/0534.vpr
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Ref
+predicate P(r: Ref)
+
+domain Frac {
+  function box(p: Perm): Frac
+  function unbox(q: Frac): Perm
+}
+
+method test1(b: Bool, x: Ref) {
+  //:: ExpectedOutput(consistency.error)
+  inhale acc(x.f, 2*wildcard)
+  //:: ExpectedOutput(consistency.error)
+  inhale acc(x.f, unbox(box(wildcard)))
+  //:: ExpectedOutput(consistency.error)
+  inhale acc(P(x), b ? wildcard : 1/2)
+}

--- a/src/test/resources/all/issues/silver/0699.vpr
+++ b/src/test/resources/all/issues/silver/0699.vpr
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Bool
+
+predicate segment(x: Ref) {
+    //:: ExpectedOutput(consistency.error)
+    acc(x.f, wildcard) && (x.f ==> acc(x.f, write - wildcard))
+}


### PR DESCRIPTION
I.e., makes it so that wildcards can only be used directly inside accessibility predicates, not as part of more complex expressions. Fixes issue #699 and addresses issue #534 at least partially.