### PR TITLE
Slightly better parse errors

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -274,9 +274,9 @@ trait SilFrontend extends DefaultFrontend {
               }
               else Fail(err_list)
             case fail @ Parsed.Failure(_, index, _) =>
-              val msg = fail.trace().longAggregateMsg
+              val msg = fail.trace().aggregateMsg
               val (line, col) = fp.lineCol.getPos(index)
-              Fail(List(ParseError(s"Expected $msg", SourcePosition(file, line, col))))
+              Fail(List(ParseError(msg, SourcePosition(file, line, col))))
             //? val pos = extra.input.prettyIndex(index).split(":").map(_.toInt)
               //? Fail(List(ParseError(s"Expected $msg", SourcePosition(file, pos(0), pos(1)))))
             case error: ParseError => Fail(List(error))


### PR DESCRIPTION
- Extracting only the relevant information from FastParse (i.e., what was expected at the point where parsing fails), instead of the whole (?) rule tree
- Renaming some parse rules, since they can be shown in the error message
- Removing an "Expected" that was in the message twice.

Before:
```
  [0] Parse error: Expected Expected entireProgram:1:1 / programDecl:4:1 / ("(" ~ exp.rep(0) ~ ")" | ":=" | "," | ";" | stmt | "}"):473:29, found "(vwa cd,nu" (test.vpr@473.29)
```

After:
```
  [0] Parse error: Expected ("(" ~ exp.rep(0) ~ ")" | ":=" | "," | ";" | stmt | "}"):473:29, found "(vwa cd,nu" (test.vpr@473.29)
```