### PR TITLE
Adding two new types of messages

### DIFF
--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -261,6 +261,11 @@ case class WarningsDuringTypechecking(warnings: Seq[TypecheckerWarning]) extends
   override val name: String = "warnings_during_typechecking"
 }
 
+case class WarningsDuringVerification(warnings: Seq[VerifierWarning]) extends Message {
+  override lazy val toString: String = s"warnings_during_verification(warnings=${warnings.toString})"
+  override val name: String = "warnings_during_verification"
+}
+
 abstract class SimpleMessage(val text: String) extends Message {
   override lazy val toString: String = s"$name(text=$text)"
   override val name: String = "simple_message"
@@ -268,6 +273,10 @@ abstract class SimpleMessage(val text: String) extends Message {
 
 case class ConfigurationConfirmation(override val text: String) extends SimpleMessage(text) {
   override val name: String = "configuration_confirmation"
+}
+
+case class AnnotationWarning(override val text: String) extends SimpleMessage(text) {
+  override val name: String = "annotation_warning"
 }
 
 case class InternalWarningMessage(override val text: String) extends SimpleMessage(text) {

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -42,6 +42,8 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
         deps.foreach(dep =>
           csv_file.write(s"ExternalDependenciesReport,${dep.name} ${dep.version} located at ${dep.location}\n")
         )
+      case AnnotationWarning(text) =>
+        csv_file.write(s"AnnotationWarning,${text}\n")
       case WarningsDuringParsing(warnings) =>
         warnings.foreach(report => {
           csv_file.write(s"WarningsDuringParsing,${report}\n")
@@ -49,6 +51,10 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
       case WarningsDuringTypechecking(warnings) =>
         warnings.foreach(report => {
           csv_file.write(s"WarningsDuringTypechecking,${report}\n")
+        })
+      case WarningsDuringVerification(warnings) =>
+        warnings.foreach(report => {
+          csv_file.write(s"WarningsDuringVerification,${report}\n")
         })
       case InvalidArgumentsReport(_, errors) =>
         errors.foreach(error => {
@@ -140,6 +146,12 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
 
       case WarningsDuringTypechecking(warnings) =>
         warnings.foreach(println)
+
+      case WarningsDuringVerification(warnings) =>
+        warnings.foreach(println)
+
+      case AnnotationWarning(text) =>
+        println(s"Annotation warning: ${text}")
 
       case InvalidArgumentsReport(_, errors) =>
         errors.foreach(e => println(s"  ${e.readableMessage}"))

--- a/src/main/scala/viper/silver/verifier/VerificationResult.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationResult.scala
@@ -92,6 +92,13 @@ case class TypecheckerWarning(message: String, override val pos: Position)
   def readableMessage = s"Type checker warning: $message ($pos)"
 }
 
+/** A case class used for treating certain verifier reports as non-critical. */
+case class VerifierWarning(message: String, override val pos: Position)
+  extends AbstractError {
+  def fullId = "verifier.warning"
+  def readableMessage = s"Verifier warning: $message ($pos)"
+}
+
 /** An error during consistency-checking an AST node */
 case class ConsistencyError(message: String, pos:Position) extends AbstractError {
   def fullId = "consistency.error"

--- a/src/test/resources/all/annotation/annotationMCE.vpr
+++ b/src/test/resources/all/annotation/annotationMCE.vpr
@@ -13,7 +13,7 @@ method disjAlias(r1: Ref, r2: Ref, r3: Ref)
     requires acc(r2.f)
     requires r3 == r1 || r3 == r2
 {
-    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /silicon/issue/000/)
     r3.f := 4
 }
 
@@ -32,7 +32,7 @@ method disjAlias2(r1: Ref, r2: Ref, r3: Ref)
     requires acc(r2.f)
     requires r3 == r1 || r3 == r2
 {
-    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /silicon/issue/000/)
     r3.f := 4
 }
 
@@ -51,7 +51,7 @@ method disjAlias4(r1: Ref, r2: Ref, r3: Ref)
     requires acc(r2.f)
     requires r3 == r1 || r3 == r2
 {
-    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /silicon/issue/000/)
     r3.f := 4
 }
 
@@ -61,6 +61,6 @@ method disjAlias5(r1: Ref, r2: Ref, r3: Ref)
     requires acc(r2.f)
     requires r3 == r1 || r3 == r2
 {
-    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    //:: UnexpectedOutput(assignment.failed:insufficient.permission, /silicon/issue/000/)
     r3.f := 4
 }

--- a/src/test/resources/all/annotation/annotationMCE.vpr
+++ b/src/test/resources/all/annotation/annotationMCE.vpr
@@ -1,0 +1,66 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+
+// Methods that have disjunctive aliasing.
+// Since this is run as part of Silicon's test suite *without* MCE, only the methods annotated to use MCE
+// are expected to pass. So the reported errors are expected in greedy, but we use UnexpectedOutput annotations
+// to mark that they're not actual errors, and that Carbon should not report them.
+
+method disjAlias(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    r3.f := 4
+}
+
+@exhaleMode("1")
+method disjAlias1(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    r3.f := 4
+}
+
+@exhaleMode("invalid")
+method disjAlias2(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    r3.f := 4
+}
+
+@exhaleMode("moreCompleteExhale")
+method disjAlias3(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    r3.f := 4
+}
+
+@exhaleMode("0")
+method disjAlias4(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    r3.f := 4
+}
+
+@exhaleMode("greedy")
+method disjAlias5(r1: Ref, r2: Ref, r3: Ref)
+    requires acc(r1.f)
+    requires acc(r2.f)
+    requires r3 == r1 || r3 == r2
+{
+    //:: UnexpectedOutput(assign.failed:insufficient.permission, /silicon/issue/000/)
+    r3.f := 4
+}

--- a/src/test/resources/all/annotation/annotationSuccess.vpr
+++ b/src/test/resources/all/annotation/annotationSuccess.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 @isghost("nope")
 field f: Int
 


### PR DESCRIPTION
Adding new messages:
- WarningsDuringVerification, which complement the existing WarningsDuringParsing and WarningsDuringTypechecking.
- AnnotationWarning, which are to be used to warn about invalid annotations.

Also adds a test for Silicon PR 724 because I did not want to make a separate PR.
Because of the test, the Silicon PR will have to be merged first.