### PR TITLE
Disable simplification of equalities

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -21,7 +21,7 @@ object Simplifier {
    * 0 are not treated. Note that an expression with non-terminating evaluation due to endless recursion
    * might be transformed to terminating expression.
    */
-  def simplify[N <: Node](n: N): N = {
+  def simplify[N <: Node](n: N, p: Program): N = {
     /* Always simplify children first, then treat parent. */
     StrategyBuilder.Slim[Node]({
       // expression simplifications
@@ -45,7 +45,9 @@ object Simplifier {
         FalseLit()(root.pos, root.info)
       case Implies(TrueLit(), consequent) => consequent
 
-      case root @ EqCmp(left, right) if left == right => TrueLit()(root.pos, root.info)
+      // ME: Disabled since it is not equivalent in case the expression is not well-defined.
+      // TODO: Consider checking if Expressions.proofObligations(left) is empty (requires adding the program as parameter).
+      // case root @ EqCmp(left, right) if left == right => TrueLit()(root.pos, root.info)
       case root @ EqCmp(BoolLit(left), BoolLit(right)) =>
         BoolLit(left == right)(root.pos, root.info)
       case root @ EqCmp(FalseLit(), right) => Not(right)(root.pos, root.info)

--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -21,7 +21,7 @@ object Simplifier {
    * 0 are not treated. Note that an expression with non-terminating evaluation due to endless recursion
    * might be transformed to terminating expression.
    */
-  def simplify[N <: Node](n: N, p: Program): N = {
+  def simplify[N <: Node](n: N): N = {
     /* Always simplify children first, then treat parent. */
     StrategyBuilder.Slim[Node]({
       // expression simplifications

--- a/src/test/scala/SimplifierTests.scala
+++ b/src/test/scala/SimplifierTests.scala
@@ -50,5 +50,11 @@ class SimplifierTests extends AnyFunSuite with Matchers {
     simplify(Mod(-3, -8)()) should be (5: IntLit)
   }
 
+  test("equality") {
+    val seqAcc = SeqIndex(EmptySeq(Int)(), 0: IntLit)()
+    // Do not simplify away definedness issues.
+    simplify(EqCmp(seqAcc, seqAcc)()) should be(EqCmp(seqAcc, seqAcc)())
+  }
+
   implicit def int2IntLit(i: Int): IntLit = IntLit(i)()
 }


### PR DESCRIPTION
Disabling simplification of ``e == e`` to ``true``, which is not equivalent in case ``e`` is not well-defined.
We could consider doing the simplification if we know ``e`` has no proof obligations (``Expressions.proofObligations`` could tell us that), but that would generally require access to the entire program (to check for function preconditions), which would break clients.