### PR TITLE
Reduce Function Call Graph Computations for Termination Plugin

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Functions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Functions.scala
@@ -45,7 +45,7 @@ object Functions {
     subexpressions
   }
 
-  /** Returns the call graph of a given program (also considering specifications as calls). Call graphs are memoized.
+  /** Returns the call graph of a given program (also considering specifications as calls).
     *
     * TODO: Memoize invocations of `getFunctionCallgraph`. Note that it's unclear how to derive a useful key from `subs`
     */

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -113,7 +113,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
   override def beforeVerify(input: Program): Program = {
     // Prevent potentially unsafe (mutually) recursive function calls in function postcondtions
     // for all functions that don't have a decreases clause
-    lazy val cycles = Functions.findFunctionCyclesVia(input, func => func.body.toSeq, func => func.body.toSeq)
+    lazy val cycles = Functions.findFunctionCyclesViaOptimized(input, func => func.body.toSeq)
     for (f <- input.functions) {
       val hasDecreasesClause = (f.pres ++ f.posts).exists(p => p.shallowCollect {
         case dc: DecreasesClause => dc


### PR DESCRIPTION
Reduces the amount of call graph computations caused by the termination plugin.
While this change seems minor, it reduces the runtime of the termination plugin's `beforeVerify` for a particular Viper AST from ~15-17s to ~1s.