### PR TITLE
Parser Warnings

### DIFF
--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -830,6 +830,8 @@ class FastParser {
   def programDecl(implicit ctx : P[_]) : P[PProgram] =
     P(FP((ParserExtension.newDeclAtStart(ctx) | preambleImport | defineDecl | fieldDecl | methodDecl | domainDecl | functionDecl | predicateDecl | ParserExtension.newDeclAtEnd(ctx)).rep).map {
     case (pos, decls) => {
+      val warnings = _warnings
+      _warnings = Seq()
       PProgram(
         decls.collect { case i: PImport => i }, // Imports
         decls.collect { case d: PDefine => d }, // Macros
@@ -839,7 +841,7 @@ class FastParser {
         decls.collect { case p: PPredicate => p }, // Predicates
         decls.collect { case m: PMethod => m }, // Methods
         decls.collect { case e: PExtender => e }, // Extensions
-        _warnings // Parse Warnings & Errors
+        warnings // Parse Warnings
       )(pos)
     }
   })

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -124,7 +124,7 @@ class FastParser {
   var _line_offset: Array[Int] = null
   /** The file we are currently parsing (for creating positions later). */
   var _file: Path = null
-  var _warnings: Seq[ParseWarning] = Seq()
+  private var _warnings: Seq[ParseWarning] = Seq()
 
   def parse(s: String, f: Path, plugins: Option[SilverPluginManager] = None) = {
     // Strategy to handle imports
@@ -839,7 +839,7 @@ class FastParser {
         decls.collect { case p: PPredicate => p }, // Predicates
         decls.collect { case m: PMethod => m }, // Methods
         decls.collect { case e: PExtender => e }, // Extensions
-        Seq() // Parse Errors
+        _warnings // Parse Warnings & Errors
       )(pos)
     }
   })


### PR DESCRIPTION
Despite [ViperServer PR #156](https://github.com/viperproject/viperserver/pull/156), I only got a type-check but no parser warnings for the following program:
```
adt List[T] {
    Nil()
    Cons(value: T, tail: List[T])
}

method test()
{
    // causes a parser warning
    var rat: Rational
    // causes a type-checker warning:
    assert Nil() == Nil()
}
```

This PR fixes the parser to actually use the `_warnings` variable that is populated during parsing. However, I'm not sure how this used to work or was intended to work