### PR TITLE
SilFrontend API for Viper frontend usage

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
@@ -82,6 +82,13 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
     hidden = true
   )
 
+  val disableDefaultPlugins = opt[Boolean]("disableDefaultPlugins",
+    descr = "Deactivate all default plugins.",
+    default = Some(false),
+    noshort = true,
+    hidden = true
+  )
+
   val plugin = opt[String]("plugin",
     descr = "Load plugin(s) with given class name(s). Several plugins can be separated by ':'. " +
       "The fully qualified class name of the plugin should be specified.",

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -52,6 +52,21 @@ trait SilFrontend extends DefaultFrontend {
     }
   }
 
+  def resetPlugins(): Unit = {
+    val pluginsArg: Option[String] = if (_config != null) {
+      // concat defined plugins and default plugins
+      val list = _config.plugin.toOption ++ (if (_config.disableDefaultPlugins()) Seq() else defaultPlugins)
+      if (list.isEmpty) {
+        None
+      } else {
+        Some(list.mkString(":"))
+      }
+    } else {
+      None
+    }
+    _plugins = SilverPluginManager(pluginsArg)(reporter, logger, _config, fp)
+  }
+
   /**
    * Create the verifier. The full command is parsed for debugging purposes only,
    * since the command line arguments will be passed later on via

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -199,13 +199,7 @@ trait SilFrontend extends DefaultFrontend {
     super.reset(input)
 
     if(_config != null) {
-
-      // concat defined plugins and default plugins
-      val pluginsArg: Option[String] = {
-        val list = _config.plugin.toOption ++ defaultPlugins
-        if (list.isEmpty) { None } else { Some(list.mkString(":")) }
-      }
-      _plugins = SilverPluginManager(pluginsArg)(reporter, logger, _config, fp)
+      resetPlugins()
     }
   }
 

--- a/src/main/scala/viper/silver/frontend/ViperFrontendAPI.scala
+++ b/src/main/scala/viper/silver/frontend/ViperFrontendAPI.scala
@@ -3,7 +3,6 @@ package viper.silver.frontend
 import viper.silver.ast.Program
 import viper.silver.verifier.VerificationResult
 
-import java.nio.file.Paths
 
 /**
   * Trait that can be mixed into SilFrontends to make them easily usable by actual Viper frontends that do not use
@@ -14,6 +13,7 @@ import java.nio.file.Paths
   * - create an instance f of a specific SilFrontend with ViperFrontendAPI mixed in
   * - call f.initialize(args), where args are the command line arguments without any file name.
   * - (potentially repeatedly) call f.verify(p), where p is the program to verify
+  * - call f.stop() when done
   * Plugin usage must be managed via command line arguments.
   * Existing implementations are SiliconFrontendAPI and CarbonFrontendAPI
   */
@@ -45,6 +45,12 @@ trait ViperFrontendAPI extends SilFrontend {
     _program = Some(p)
     runAllPhases()
     result
+  }
+
+  def stop(): Unit = {
+    if (!initialized)
+      throw new IllegalStateException("Not initialized")
+    _verifier.foreach(_.stop())
   }
 
 }

--- a/src/main/scala/viper/silver/frontend/ViperFrontendAPI.scala
+++ b/src/main/scala/viper/silver/frontend/ViperFrontendAPI.scala
@@ -1,0 +1,38 @@
+package viper.silver.frontend
+
+import viper.silver.ast.Program
+import viper.silver.verifier.VerificationResult
+
+import java.nio.file.Paths
+
+trait ViperFrontendAPI extends SilFrontend {
+
+  private var initialized = false
+  override val phases: Seq[Phase] = Seq(ConsistencyCheck, Verification)
+  val dummyInputFilename = "dummy-file-to-prevent-cli-parser-from-complaining-about-missing-file-name.silver"
+
+  def initialize(args: Seq[String]): Unit = {
+    // create verifier
+    // parse args on frontend, set on verifier
+    val v = createVerifier(args.mkString(" "))
+    setVerifier(v)
+    _verifier = Some(v)
+    parseCommandLine(args :+ "--ignoreFile" :+ dummyInputFilename)
+    resetPlugins()
+    initialized = true
+  }
+
+  protected def setStartingState() = {
+    _state = DefaultStates.ConsistencyCheck
+  }
+
+  def verify(p: Program): VerificationResult = {
+    if (!initialized)
+      println("Not initialized")
+    setStartingState()
+    _program = Some(p)
+    runAllPhases()
+    result
+  }
+
+}

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -93,7 +93,7 @@ case class MapEntry(options: Map[Seq[ValueEntry], ValueEntry], default: ValueEnt
         val indices = args.map(_.get._1)
         // We expect the arguments in the order 0, 1, ..., n-1; if we get something else, reject.
         // TODO: Find out if this order is always guaranteed,
-        if (indices != (0 until indices.size))
+        if (indices != (0 until indices.size).map(_.toString))
           None
         else
           Some(args.map(_.get._2))


### PR DESCRIPTION
- Offers a new trait with two methods for easy usage of ``SilFrontend`` by actual Viper frontends. Compared to working with ``Verifier`` instances directly, these take care of plugins (i.e., they run the relevant plugin phases automatically; command line arguments can be used to select which plugins to run) and don't require calling a bunch of boilerplate methods. Compared to existing ``SilFrontend`` classes, these are made to be used by frontends (without parsing etc.) and correctly pass command line options to plugins.
- Usage is simple:
  ```
  val f = new SiliconFrontendAPI(reporter)  // or CarbonFrontendAPI, or MinimalSiliconFrontendAPI (skips consistency checks)
  f.initialize(args) // command line arguments without any dummy filename
  val res1 = f.verify(program1)
  val res2 = f.verify(program2)
  f.stop()
  ```
- Re-added option to disable default plugins.

Tested with adapted versions of Prusti and Nagini.