### PR TITLE
Auto-generating well-foundedness axioms for ADT types in the ADT plugin

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
@@ -110,7 +110,7 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
     case i => throw new IllegalArgumentException(s"Unsupported counterexample model provided. Expected 'native', 'variables' or 'mapped' but got $i")
   }))
 
-  val terminationPlugin = opt[Boolean]("disableTerminationPlugin",
+  val disableTerminationPlugin = opt[Boolean]("disableTerminationPlugin",
     descr = "Disable the termination plugin, which adds termination checks to functions, " +
       "methods and loops.",
     default = Some(false),
@@ -118,7 +118,7 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
     hidden = true
   )
 
-  val adtPlugin = opt[Boolean]("disableAdtPlugin",
+  val disableAdtPlugin = opt[Boolean]("disableAdtPlugin",
     descr = "Disable the ADT plugin, which adds support for ADTs as a built-in type.",
     default = Some(false),
     noshort = true,

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
@@ -34,6 +34,8 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
     */
   private var derivesImported: Boolean = false
 
+  private def isTerminationPluginActive: Boolean = true // config != null && config.terminationPlugin.toOption.getOrElse(false)
+
   def adtDerivingFunc[$: P]: P[PIdnUse] = FP(StringIn("contains").!).map { case (pos, id) => PIdnUse(id)(pos) }
 
   override def beforeParse(input: String, isImported: Boolean): String = {
@@ -131,7 +133,7 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
     if (deactivated) {
       return input
     }
-    new AdtEncoder(input).encode()
+    new AdtEncoder(input).encode(isTerminationPluginActive)
   }
 
 }

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
@@ -40,10 +40,6 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
         config.plugin.toOption.getOrElse("").split(":").contains("viper.silver.plugin.standard.termination.TerminationPlugin"))
   }
 
-  private def generateWellFoundednessAxioms(prog: Program): Boolean = {
-    isTerminationPluginActive && prog.domainsByName.contains("WellFoundedOrder")
-  }
-
   def adtDerivingFunc[$: P]: P[PIdnUse] = FP(StringIn("contains").!).map { case (pos, id) => PIdnUse(id)(pos) }
 
   override def beforeParse(input: String, isImported: Boolean): String = {
@@ -141,7 +137,7 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
     if (deactivated) {
       return input
     }
-    new AdtEncoder(input).encode(generateWellFoundednessAxioms(input))
+    new AdtEncoder(input).encode(isTerminationPluginActive)
   }
 
 }

--- a/src/main/scala/viper/silver/plugin/standard/adt/encoding/AdtEncoder.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/encoding/AdtEncoder.scala
@@ -484,7 +484,7 @@ class AdtEncoder(val program: Program) extends AdtNameManager {
     }
 
 
-    AnonymousDomainAxiom(body)(ac.pos, ac.info, ac.adtName, ac.errT)
+    AnonymousDomainAxiom(body)(ac.pos, ac.info, getWellFoundedDomainName(domain.name), ac.errT)
   }
 
   /**

--- a/src/main/scala/viper/silver/plugin/standard/adt/encoding/AdtNameManager.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/encoding/AdtNameManager.scala
@@ -41,6 +41,11 @@ trait AdtNameManager {
 
   def getContainsFunctionName: String = "contains"
 
+  def getWellFoundedDomainName(typeName: String): String = typeName + "WellFoundedOrder"
+  def getWellFoundedOrderDeclarationDomainName : String = "WellFoundedOrder"
+  def getDecreasesFunctionName: String = "decreasing"
+  def getBoundedFunctionName: String = "bounded"
+
   def getContainsTransitivityDomain: String = getName("ContainsTransitivityDomain")
 
   /**

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -29,7 +29,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
                         fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
   import fp.{FP, keyword, exp, ParserExtension}
 
-  private def deactivated: Boolean = config != null && config.terminationPlugin.toOption.getOrElse(false)
+  private def deactivated: Boolean = config != null && config.disableTerminationPlugin.toOption.getOrElse(false)
 
   private var decreasesClauses: Seq[PDecreasesClause] = Seq.empty
 

--- a/src/test/resources/adt/termination_1.vpr
+++ b/src/test/resources/adt/termination_1.vpr
@@ -1,0 +1,105 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+domain Val {}
+
+adt List[V] {
+    Nil()
+    Cons(value: V, tail: List[V])
+}
+
+function len(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isNil ? 0 : 1 + len(l.tail)
+}
+
+function len2(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isNil ? 0 : (l.tail.isNil ? 1 : 2 + len2(l.tail.tail))
+}
+
+function lenBad(l: List[Val], v: Val): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ lenBad(Cons(v, Nil()), v)
+}
+
+function lenBad2(l: List[Val]): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ 1 + lenBad2(l)
+}
+
+////////////////////////
+
+adt IntList {
+    INil()
+    ICons(ivalue: Int, itail: IntList)
+}
+
+function ilen(l: IntList): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isINil ? 0 : 1 + ilen(l.itail)
+}
+
+function ilen2(l: IntList): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isINil ? 0 : (l.itail.isINil ? 1 : 2 + ilen2(l.itail.itail))
+}
+
+function ilenBad(l: IntList, v: Int): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ ilenBad(ICons(v, INil()), v)
+}
+
+////////////////////////
+
+// non-recursive data type with two type variables
+adt Pair[T, V] {
+    pair(fst: T, snd: V)
+}
+
+function stupidFunc(p: Pair[Int, Val]): Val
+  decreases p
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  stupidFunc(p)
+}
+
+// two type variables
+adt DList[V, T] {
+    DNil()
+    DCons(dvalue1: V, dvalue2: T, dtail: DList[V, T])
+}
+
+function dlen(l: DList[Int, Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isDNil ? 0 : 1 + dlen(l.dtail)
+}
+
+function dlenBad(l: DList[Int, Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  l.isDNil ? 0 : 1 + dlenBad(l)
+}
+

--- a/src/test/resources/adt/termination_2.vpr
+++ b/src/test/resources/adt/termination_2.vpr
@@ -1,0 +1,44 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+// Part of termination_1.vpr, but with the WellFoundedness domain already there.
+import <decreases/declaration.vpr>
+
+
+domain Val {}
+
+adt List[V] {
+    Nil()
+    Cons(value: V, tail: List[V])
+}
+
+function len(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isNil ? 0 : 1 + len(l.tail)
+}
+
+function len2(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  l.isNil ? 0 : (l.tail.isNil ? 1 : 2 + len2(l.tail.tail))
+}
+
+function lenBad(l: List[Val], v: Val): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ lenBad(Cons(v, Nil()), v)
+}
+
+function lenBad2(l: List[Val]): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ 1 + lenBad2(l)
+}

--- a/src/test/resources/adt/termination_3.vpr
+++ b/src/test/resources/adt/termination_3.vpr
@@ -1,0 +1,51 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+// Part of termination_1.vpr, but with the WellFoundedness domain already there and a custom domain for
+// the list well founded order.
+import <decreases/declaration.vpr>
+
+domain ListWellFoundedOrder[W] {
+    // Domain already being present will prevent auto-generation of axioms.
+    // Thus, we should not be able to prove termination based on List measures here.
+}
+
+domain Val {}
+
+adt List[V] {
+    Nil()
+    Cons(value: V, tail: List[V])
+}
+
+function len(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  l.isNil ? 0 : 1 + len(l.tail)
+}
+
+function len2(l: List[Val]): Int
+  ensures result >= 0
+  decreases l
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  l.isNil ? 0 : (l.tail.isNil ? 1 : 2 + len2(l.tail.tail))
+}
+
+function lenBad(l: List[Val], v: Val): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ lenBad(Cons(v, Nil()), v)
+}
+
+function lenBad2(l: List[Val]): Int
+ ensures result >= 0
+ decreases l
+{
+ //:: ExpectedOutput(termination.failed:tuple.false)
+ 1 + lenBad2(l)
+}

--- a/src/test/resources/adt/termination_mutual_1.vpr
+++ b/src/test/resources/adt/termination_mutual_1.vpr
@@ -1,0 +1,35 @@
+adt List1 {
+  RList1(x: Int, l: List2)
+}
+adt List2 {
+  Empty()
+  NonEmpty(l: List1)
+}
+
+
+function len2(l: List2): Int
+    decreases l
+{
+    l == Empty()? 0 : 1 + len2(l.l.l)
+}
+
+
+function len2Bad(l: List2): Int
+    decreases l
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    l == Empty()? 0 : 1 + len2Bad(l)
+}
+
+function len1(l: List1): Int
+    decreases l
+{
+    l.l == Empty()? 0 : 1 + len1(l.l.l)
+}
+
+function len1Bad(l: List1): Int
+    decreases l
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    l.l == Empty()? 0 : 1 + len1Bad(l)
+}

--- a/src/test/resources/adt/termination_mutual_1.vpr
+++ b/src/test/resources/adt/termination_mutual_1.vpr
@@ -1,9 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// Mutually recursive ADTs
 adt List1 {
   RList1(x: Int, l: List2)
 }
 adt List2 {
   Empty()
-  NonEmpty(l: List1)
+  NonEmpty(x: Int, l: List1)
 }
 
 
@@ -32,4 +36,73 @@ function len1Bad(l: List1): Int
 {
     //:: ExpectedOutput(termination.failed:tuple.false)
     l.l == Empty()? 0 : 1 + len1Bad(l)
+}
+
+// Name clash between y: MList2 and y: Int
+adt MList1 {
+  MRList1(x: Int, y: MList2)
+}
+adt MList2 {
+  MEmpty()
+  MNonEmpty(y: Int, l: MList1)
+}
+
+
+function mlen2(l: MList2): Int
+    decreases l
+{
+    l == MEmpty()? 0 : 1 + mlen2(l.l.y)
+}
+
+// Three mutually recursive types
+adt Triple1 {
+  triple1(x: Triple2)
+}
+
+adt Triple2 {
+  triple2(x: Triple3)
+}
+
+adt Triple3 {
+  triple3(x: Triple1)
+  nil(i: Int)
+}
+
+function tripleLen1(t: Triple1): Int
+    decreases t
+{
+    2 + (t.x.x.isnil ? 0 : tripleLen1(t.x.x.x))
+}
+
+function tripleLen2(t: Triple2): Int
+    decreases t
+{
+    1 + (t.x.isnil ? 0 : (1 + tripleLen2(t.x.x.x)))
+}
+
+function tripleLen3(t: Triple3): Int
+    decreases t
+{
+    t.isnil ? 0 : (3 + tripleLen3(t.x.x.x))
+}
+
+function tripleLen1Bad(t: Triple1): Int
+    decreases t
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    2 + (t.x.x.isnil ? 0 : tripleLen1Bad(t))
+}
+
+function tripleLen2Bad(t: Triple2): Int
+    decreases t
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    1 + (t.x.isnil ? 0 : (1 + tripleLen2Bad(t)))
+}
+
+function tripleLen3Bad(t: Triple3): Int
+    decreases t
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    t.isnil ? 0 : (3 + tripleLen3Bad(t))
 }

--- a/src/test/resources/all/issues/silicon/0751.vpr
+++ b/src/test/resources/all/issues/silicon/0751.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 domain $domain$to_int  {
 
   function to_int(to_int1: Perm): Int interpretation "to_int"
@@ -5,8 +8,9 @@ domain $domain$to_int  {
 
 function round(x: Perm): Perm
   decreases
+  ensures x == 3/1 ==> result == 3/2
   //:: ExpectedOutput(postcondition.violated:assertion.false)
   ensures result == to_int(x) / 1
 {
-  to_int(x + (1/2)) / 1
+  to_int(x) / 2
 }

--- a/src/test/resources/termination/functions/basic/preventAutoImport.vpr
+++ b/src/test/resources/termination/functions/basic/preventAutoImport.vpr
@@ -1,0 +1,18 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import <decreases/declaration.vpr>
+
+domain IntWellFoundedOrder{
+	// Domain already being present will prevent auto-import of the default domain.
+	// Thus, we have no defined order for type Int and proofs should fail.
+}
+
+//Example decreasing Int
+function fact(x:Int): Int
+  decreases x
+  requires x>=0
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    x==0 ? 1 : x*fact(x-1)
+}


### PR DESCRIPTION
This PR extends the ADT plugin to generate an additional domain ``TWellFoundedOrder`` for every ADT type ``T`` that constrains the ``decreasing`` and ``bounded`` functions used in termination checks in the obvious way, so that users can write clauses like ``decreases t`` for a parameter ``t`` of an ADT type by default.

The additional domain is generated for an ADT type ``T`` iff:
- The termination plugin is not deactivated
- The program contains a ``WellFoundedOrder`` domain, i.e., the ``decreasing`` and ``bounded`` functions are actually declared
- The program does not yet contain domain ``TWellFoundedOrder``, i.e., there is no user-provided definition of the well-foundedness order for this type yet.

The generated domain for type ``T`` and recursive constructor ``C1(T)`` and non-recursive constructor ``C2(V)`` looks as follows:
```
domain TWellFoundedOrder {
  axiom {
    forall v: V :: { C2(v) } bounded(C2(v))
  }
  axiom {
    forall t: T :: { C1(t) } bounded(C1(t)) && decreasing(t, C1(t))
  }
  axiom {
    forall v1: T, v2: T, v3: T :: { decreasing(v1, v2), decreasing(v2, v3) }
      decreasing(v1, v2) && decreasing(v2, v3) ==> decreasing(v1, v3)
  }
}
```