### PR TITLE
Smoke Detection Plugin

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
@@ -82,6 +82,13 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
     hidden = true
   )
 
+  val enableSmokeDetection = opt[Boolean]("enableSmokeDetection",
+    descr = "Enable smoke detection (if enabled, refute false statements are inserted in the code in order to detect unsound specifications).",
+    default = Some(false),
+    noshort = true,
+    hidden = false
+  )
+
   val disableDefaultPlugins = opt[Boolean]("disableDefaultPlugins",
     descr = "Deactivate all default plugins.",
     default = Some(false),

--- a/src/main/scala/viper/silver/plugin/standard/refute/RefuteErrors.scala
+++ b/src/main/scala/viper/silver/plugin/standard/refute/RefuteErrors.scala
@@ -6,6 +6,8 @@
 
 package viper.silver.plugin.standard.refute
 
+import viper.silver.ast.FalseLit
+import viper.silver.plugin.standard.smoke.SmokeDetectionInfo
 import viper.silver.verifier._
 
 sealed abstract class RefuteError extends ExtensionAbstractVerificationError
@@ -13,7 +15,9 @@ sealed abstract class RefuteErrorReason extends ExtensionAbstractErrorReason
 
 case class RefuteFailed(override val offendingNode: Refute, override val reason: ErrorReason, override val cached: Boolean = false) extends RefuteError {
   override val id = "refute.failed"
-  override val text = "Refute holds in all cases or could not be reached (e.g. see Silicon `numberOfErrorsToReport`)."
+  override val text: String = if (offendingNode.exp.isInstanceOf[FalseLit] && offendingNode.info.getUniqueInfo[SmokeDetectionInfo].isDefined)
+    "Smoke detection: False could be proven here (which should never hold)." else
+    "Refute holds in all cases or could not be reached (e.g. see Silicon `numberOfErrorsToReport`)."
 
   override def withNode(offendingNode: errors.ErrorNode = this.offendingNode): RefuteFailed =
     RefuteFailed(this.offendingNode, this.reason, this.cached)

--- a/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/refute/RefutePlugin.scala
@@ -56,7 +56,7 @@ class RefutePlugin(@unused reporter: viper.silver.reporter.Reporter,
             If(nonDetLocalVarDecl.localVar,
               Seqn(Seq(
                 Assert(exp)(r.pos, RefuteInfo(r)),
-                Inhale(BoolLit(false)(r.pos))(r.pos)
+                Inhale(BoolLit(false)(r.pos))(r.pos, Synthesized)
               ), Seq())(r.pos),
               Seqn(Seq(), Seq())(r.pos))(r.pos)
           ),

--- a/src/main/scala/viper/silver/plugin/standard/smoke/SmokeDetectionPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/smoke/SmokeDetectionPlugin.scala
@@ -1,0 +1,235 @@
+package viper.silver.plugin.standard.smoke
+
+import fastparse.P
+import viper.silver.ast._
+import viper.silver.ast.utility.ViperStrategy
+import viper.silver.cfg.silver.SilverCfg
+import viper.silver.cfg.silver.SilverCfg.SilverBlock
+import viper.silver.parser.FastParser
+import viper.silver.plugin.standard.refute.Refute
+import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
+
+import scala.annotation.unused
+import scala.collection.mutable.ListBuffer
+
+class SmokeDetectionPlugin(@unused reporter: viper.silver.reporter.Reporter,
+                           @unused logger: ch.qos.logback.classic.Logger,
+                           @unused config: viper.silver.frontend.SilFrontendConfig,
+                           fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
+
+  import fp.{FP, ParserExtension, keyword}
+
+  /** Keyword used to define `unreachable` statement. */
+  private val unreachableKeyword: String = "unreachable"
+
+  /** Parser for `unreachable` statements. */
+  def unreachable[$: P]: P[PUnreachable] =
+    FP(keyword(unreachableKeyword)).map { case (pos, _) => PUnreachable()(pos) }
+
+  /** Add `unreachable` to the parser. */
+  override def beforeParse(input: String, isImported: Boolean): String = {
+    // Add new keyword
+    ParserExtension.addNewKeywords(Set[String](unreachableKeyword))
+    // Add new parser to the precondition
+    ParserExtension.addNewStmtAtEnd(unreachable(_))
+    input
+  }
+
+  override def beforeVerify(input: Program): Program = {
+    var refuteId = 0
+
+    // Add `refute false` at end of each method body
+    val transformedMethods = input.methods.map(method => {
+      val bodyWithRefute = if (method.body.isEmpty) method.body else
+        Option(Seqn(method.body.toSeq :+ refuteFalse(method.pos, refuteId), Seq())(method.pos))
+
+      Method(method.name, method.formalArgs, method.formalReturns, method.pres,
+        method.posts, bodyWithRefute)(method.pos, method.info, method.errT)
+    })
+
+    // Add `refute false` after each inhale, at end of each loop body, at end of each if/else branch and before each goto
+    val methodsWithRefutes = transformedMethods.map(method => {
+      ViperStrategy.Slim({
+        case i@Inhale(expr) if i.info.getUniqueInfo[Synthesized.type].isEmpty =>
+          refuteId += 1
+          appendRefuteFalse(Inhale(expr)(i.pos, Synthesized), i.pos, refuteId)
+        case w@While(cond, invs, body) =>
+          refuteId += 1
+          While(cond, invs, appendRefuteFalse(body, body.pos, refuteId))(w.pos)
+        case i@If(cond, thn, els) =>
+          var thnWithRefute: Seqn = thn
+          var elsWithRefute: Seqn = els
+
+          if (thn.ss.nonEmpty) {
+            refuteId += 1
+            thnWithRefute = appendRefuteFalse(thn, thn.pos, refuteId)
+          }
+
+          if (els.ss.nonEmpty) {
+            refuteId += 1
+            elsWithRefute = appendRefuteFalse(els, els.pos, refuteId)
+          }
+
+          If(cond, thnWithRefute, elsWithRefute)(i.pos)
+        case g@Goto(target) if g.info.getUniqueInfo[Synthesized.type].isEmpty =>
+          refuteId += 1
+          Seqn(Seq(refuteFalse(g.pos, refuteId), Goto(target)(g.pos, Synthesized)), Seq())(g.pos)
+      }).execute[Method](method)
+    })
+
+    // Remove all `refute false` statements which are inside of control-flow branch marked as unreachable
+    val methodsWithoutUnreachableRefutes = methodsWithRefutes.map(method => {
+      val cfg = method.toCfg(simplify = false)
+      val result = collectRefutesToKeep(cfg)
+
+      ViperStrategy.Slim({
+        case r@Refute(_) =>
+          val info = r.info.getUniqueInfo[SmokeDetectionInfo]
+
+          if (info.isDefined &&
+            !result._1.contains(info.get.id) && // not marked reachable
+            result._2.contains(info.get.id)) { // actually considered when traversing CFG
+            Seqn(Seq(), Seq())(r.pos) // remove refute statement
+          } else {
+            r
+          }
+        case u@Unreachable() =>
+          Seqn(Seq(), Seq())(u.pos)
+      }).execute[Method](method)
+    })
+
+    Program(input.domains, input.fields, input.functions, input.predicates, methodsWithoutUnreachableRefutes,
+      input.extensions)(input.pos, input.info, input.errT)
+  }
+
+  /**
+   * Construct a [[Seqn]] consisting of `stmt` followed by a `refute false` statement with position `pos`.
+   * The `Refute` instance will have the ID `refuteId`.
+   *
+   * @param stmt     the statement at the beginning of the sequence
+   * @param pos      the position of the resulting [[Seqn]] instance
+   * @param refuteId the ID of the `refute false` statement at the end of the sequence
+   * @return a [[Seqn]] instance consisting of `stmt` and a `refute false` statement
+   */
+  private def appendRefuteFalse(stmt: Stmt, pos: Position, refuteId: Int): Seqn = {
+    Seqn(Seq(stmt, refuteFalse(pos, refuteId)), Seq())(pos)
+  }
+
+  /**
+   * Construct a `refute false` statement with position `pos` and ID `id`.
+   *
+   * @param pos the position of the resulting [[Refute]] instance
+   * @param id  the ID of the `refute false` statement
+   * @return a [[Refute]] instance with with the `exp` set to `false` and the given position and ID
+   */
+  private def refuteFalse(pos: Position, id: Int): Refute = {
+    Refute(FalseLit()(pos))(pos, SmokeDetectionInfo(id))
+  }
+
+  /**
+   * Construct a list of the IDs of all `refute false` statements that are not marked unreachable.
+   *
+   * @param cfg the control-flow graph of a method
+   * @return a list of the IDs of the reachable `refute false` statements and a list of the IDs of the `refute false`
+   *         statements that were encountered when traversing the control-flow graph
+   */
+  private def collectRefutesToKeep(cfg: SilverCfg): (List[Int], List[Int]) = {
+    val refutesToKeep = ListBuffer[Int]()
+    val seenRefutes = ListBuffer[Int]()
+    collectRefutesToKeepUntilExit(cfg, cfg.entry, cfg.exit.toSeq, ListBuffer[SilverBlock](),
+      refutesToKeep, seenRefutes, unreachable = false)
+    (refutesToKeep.toList, seenRefutes.toList)
+  }
+
+  /**
+   * Recursively construct a list of the IDs of all `refute false` statements that are not marked as unreachable on the
+   * path from the node `current` to one of the nodes in `exits` in the control-flow graph `cfg`.
+   *
+   * @param cfg           the control-flow graph
+   * @param current       the currently considered node in the control-flow graph
+   * @param exits         a list of potential exit nodes of the currently considered subgraph
+   * @param seen          a list of all nodes of the control-flow graph that have already been visited
+   * @param refutesToKeep the list of the IDs of all `refute false` statements which are not on an unreachable path
+   * @param seenRefutes the list of the IDs of all `refute false` statements that were already considered
+   * @param unreachable   indicates whether the current node is on a path marked as unreachable
+   * @return `true` if some part of the path from the `current` node to one of the `exits` is unreachable, otherwise `false`
+   */
+  private def collectRefutesToKeepUntilExit(cfg: SilverCfg,
+                                            current: SilverBlock,
+                                            exits: Seq[SilverBlock],
+                                            seen: ListBuffer[SilverBlock],
+                                            refutesToKeep: ListBuffer[Int],
+                                            seenRefutes: ListBuffer[Int],
+                                            unreachable: Boolean): Boolean = {
+    seen += current
+    val elements = current.elements
+
+    var unreachableSuccessors = unreachable
+
+    for (elem <- elements) {
+      val leftElem = elem.left.getOrElse(null)
+
+      leftElem match {
+        case _: Unreachable =>
+          // Encountered `unreachable` statement -> successors of current node are unreachable
+          unreachableSuccessors = true
+        case refute: Refute if refute.exp.isInstanceOf[FalseLit] =>
+          // Encountered `refute false` statement -> add ID to list if it is reachable
+          val info = refute.info.getUniqueInfo[SmokeDetectionInfo]
+
+          if (info.isDefined) {
+            val id = info.get.id
+
+            if (!unreachableSuccessors) {
+              refutesToKeep += id
+            }
+
+            seenRefutes += id
+          }
+        case _ =>
+      }
+    }
+
+    if (exits.contains(current)) {
+      // Considered whole path
+      return unreachableSuccessors
+    }
+
+    val successors = cfg.successors(current).filter(s => !seen.contains(s))
+    val joinPointMap = cfg.joinPoints
+
+    if (joinPointMap.contains(current)) {
+      // Current node is branch point
+      val joinPoint = joinPointMap(current)
+      val joinPointPredecessors = cfg.predecessors(joinPoint)
+      var allBranchesUnreachable = true
+
+      for (elem <- successors) {
+        val unreachableBranch = collectRefutesToKeepUntilExit(cfg, elem, joinPointPredecessors, seen,
+          refutesToKeep, seenRefutes, unreachableSuccessors)
+        if (!unreachableBranch) {
+          allBranchesUnreachable = false
+        }
+      }
+
+      // If all paths from the branch point to the join point contain an `unreachable` statement, the code following
+      // the joint point (including the join point) is also unreachable.
+      return collectRefutesToKeepUntilExit(cfg, joinPoint, exits, seen, refutesToKeep, seenRefutes, allBranchesUnreachable)
+    }
+
+    // Current node is no branch point -> collect Refute IDs for successor node
+    successors.forall(s => collectRefutesToKeepUntilExit(cfg, s, exits, seen, refutesToKeep, seenRefutes, unreachableSuccessors))
+  }
+}
+
+/**
+ * An info used to mark AST nodes (more specifically, `refute false` statements) as used in smoke detection,
+ * also assigning a unique identifier to it.
+ *
+ * @param id the ID of the node
+ */
+case class SmokeDetectionInfo(id: Int) extends Info {
+  override def comment: Seq[String] = Seq(s"`refute false` #$id")
+
+  override def isCached: Boolean = false
+}

--- a/src/main/scala/viper/silver/plugin/standard/smoke/UnreachableASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/smoke/UnreachableASTExtension.scala
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+package viper.silver.plugin.standard.smoke
+
+import viper.silver.ast._
+import viper.silver.ast.pretty.FastPrettyPrinter.text
+import viper.silver.ast.pretty.PrettyPrintPrimitives
+
+case class Unreachable()(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends ExtensionStmt {
+
+  override lazy val prettyPrint: PrettyPrintPrimitives#Cont = text("unreachable")
+
+  override def extensionSubnodes: Seq[Node] = Seq()
+}
+

--- a/src/main/scala/viper/silver/plugin/standard/smoke/UnreachablePASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/smoke/UnreachablePASTExtension.scala
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+package viper.silver.plugin.standard.smoke
+
+import viper.silver.ast.{Position, Stmt}
+import viper.silver.parser._
+
+case class PUnreachable()(val pos: (Position, Position)) extends PExtender with PStmt {
+  override val getSubnodes: Seq[PNode] = Seq()
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+    None
+  }
+
+  override def translateStmt(t: Translator): Stmt = Unreachable()(t.liftPos(this))
+}

--- a/src/test/resources/smoke/axiom.vpr
+++ b/src/test/resources/smoke/axiom.vpr
@@ -1,0 +1,10 @@
+domain Foo {
+  axiom unsound {
+    false
+  }
+}
+
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test()
+{
+}

--- a/src/test/resources/smoke/if.vpr
+++ b/src/test/resources/smoke/if.vpr
@@ -1,0 +1,19 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method x()
+    ensures false
+{
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    assume 0 == 1
+}
+
+method test()
+{
+    var b: Bool
+
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    if (b) {
+        x()
+    } else {
+        
+    }
+}

--- a/src/test/resources/smoke/infinite_loop-goto.vpr
+++ b/src/test/resources/smoke/infinite_loop-goto.vpr
@@ -1,0 +1,6 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test()
+{
+    label l0
+    goto l0
+}

--- a/src/test/resources/smoke/infinite_loop-while.vpr
+++ b/src/test/resources/smoke/infinite_loop-while.vpr
@@ -1,0 +1,7 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test()
+{
+    while (true)
+    {
+    }
+}

--- a/src/test/resources/smoke/inhale-1.vpr
+++ b/src/test/resources/smoke/inhale-1.vpr
@@ -1,0 +1,5 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test() {
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    assume false
+}

--- a/src/test/resources/smoke/inhale-2.vpr
+++ b/src/test/resources/smoke/inhale-2.vpr
@@ -1,0 +1,8 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test() returns (res: Int)
+    ensures res == 1
+{
+    res := 2
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    assume res == 1
+}

--- a/src/test/resources/smoke/inhale-3.vpr
+++ b/src/test/resources/smoke/inhale-3.vpr
@@ -1,0 +1,9 @@
+field x: Int
+
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test(a: Ref)
+{
+    inhale acc(a.x)
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    inhale acc(a.x)
+}

--- a/src/test/resources/smoke/loop.vpr
+++ b/src/test/resources/smoke/loop.vpr
@@ -1,0 +1,14 @@
+function foo(): Bool
+{
+    false
+}
+
+method test(a: Bool)
+{
+
+    //:: ExpectedOutput(refute.failed:refutation.true)
+    while (a) {
+        //:: ExpectedOutput(refute.failed:refutation.true)
+        assume foo()
+    }
+}

--- a/src/test/resources/smoke/method-abstract.vpr
+++ b/src/test/resources/smoke/method-abstract.vpr
@@ -1,0 +1,2 @@
+method abstract()
+    requires false

--- a/src/test/resources/smoke/method.vpr
+++ b/src/test/resources/smoke/method.vpr
@@ -1,0 +1,5 @@
+//:: ExpectedOutput(refute.failed:refutation.true)
+method test()
+    requires false
+{
+}

--- a/src/test/resources/smoke/unreachable-1.vpr
+++ b/src/test/resources/smoke/unreachable-1.vpr
@@ -1,0 +1,5 @@
+method test()
+    requires false
+{
+    unreachable
+}

--- a/src/test/resources/smoke/unreachable-2.vpr
+++ b/src/test/resources/smoke/unreachable-2.vpr
@@ -1,0 +1,27 @@
+method test7(a: Bool)
+    requires !a
+{
+
+    if (a) {
+        unreachable
+        assume false
+    }
+
+    if (a) {
+        unreachable
+        while (a) {
+            assume false
+
+            if (a) {
+                assume false
+            }
+        }
+    }
+
+    while (a) {
+        unreachable
+        if (a) {
+            assume false
+        }
+    }
+}

--- a/src/test/resources/smoke/unreachable-3.vpr
+++ b/src/test/resources/smoke/unreachable-3.vpr
@@ -1,0 +1,25 @@
+method test(a: Bool)
+    requires !a
+{
+    if (a) {
+        unreachable
+    }
+    
+
+    var x: Int := 1
+
+    if (a) {
+        //:: ExpectedOutput(refute.failed:refutation.true)
+        assume false
+        unreachable
+        x := 0
+
+        if (x == 1) {
+            assume false
+
+            if (x == 1) {
+                assume false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the option to automatically detect contradictions in specifications (we call this smoke detection), which lead to the verifier being able to prove anything (even `false`). This is done by inserting `refute false` at various locations in the code; if one of them fails, the specification is unsound. More specifically, these `refute` statements are added

- at the end of each method body (to catch unsatisfiable preconditions),
- at the end of each loop body,
- at the end of each if/else body,
- before each `goto` statement and
- after each `assume` and `inhale` statement (for more fine-grained error reporting; in theory, this would not be necessary).

In order to avoid false positives, this pull request also introduces the `unreachable` statement, which is used to mark pieces of code as not reachable. As a result, no `refute false` statements are inserted inside of an unreachable branch. To illustrate the problem, consider the following example:
```
method test(a: Bool)
    requires a
{
    if (!a)
    {
        assume false
    }
}
```
Here, the smoke detection plugin would raise an error because `false` can be proven inside of the body of the `if` statement. However, since the precondition requires that `a` is `true`, the body of the `if` statement is not reachable. Hence, in order to avoid getting the error, one can add an `unreachable` statement inside of the `if` branch:
```
method test(a: Bool)
    requires a
{
    if (!a)
    {
        unreachable
        assume false
    }
}
```
The `unreachable` statement marks the current branch in the control flow as not reachable. This holds until the next join point - in this case, until the end of the body of the `if` branch. When verifying this example with smoke detection enabled, the plugin reports no errors.

Smoke detection is disabled by default and can be enabled by providing the option `--enableSmokeDetection`.