### PR TITLE
Avoiding folds in the encoding of unfolding expressions

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
@@ -62,7 +62,7 @@ trait ExpTransformer extends ProgramManager with ErrorReporter {
       val assumeFalse = Inhale(FalseLit()())()
       val thenBranch = Seqn(Seq(permCheck, unfold, unfoldBody, assumeFalse), Nil)()
       val elseBranch = if (inhaleExp) Seqn(Seq(Inhale(e)(e.pos, e.info)), Nil)() else EmptyStmt
-      If(nonDetVarDecl.localVar, thenBranch, elseBranch)()
+      Seqn(Seq(If(nonDetVarDecl.localVar, thenBranch, elseBranch)()), Seq(nonDetVarDecl))()
     case Applying(wand, body) =>
       // note that this case is untested -- it's not possible to write a function with an `applying` expression
       val nonDetVarDecl = LocalVarDecl(uniqueName("b"), Bool)(e.pos, e.info, e.errT)

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/ExpTransformer.scala
@@ -57,7 +57,6 @@ trait ExpTransformer extends ProgramManager with ErrorReporter {
     case Unfolding(acc, unfBody) =>
       val permCheck = transformExp(acc.perm, c, false)
       val unfoldBody = transformExp(unfBody, c, inhaleExp)
-      // only unfold and fold if body contains something
       val unfold = Unfold(acc)()
       val nonDetVarDecl = LocalVarDecl(uniqueName("b"), Bool)(e.pos, e.info, e.errT)
       val assumeFalse = Inhale(FalseLit()())()


### PR DESCRIPTION
This avoids having to prove that the predicate can be folded, which is not needed (but can still sometimes fail e.g. if wildcard multiplications lead to non-linear terms, like in an example that @jcp19 found).