### PR TITLE
Implement filtering of duplicate errors in SilFrontend

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -268,12 +268,17 @@ trait SilFrontend extends DefaultFrontend {
     _verificationResult = _verificationResult.map(plugins.mapVerificationResult(_program.get, _))
   }
 
+  /**
+    * Finish verification and report results via the reporter. This method is intended to be called only when
+    * Viper is called as a standalone application (i.e., not from a frontend).
+    */
   def finish(): Unit = {
     val tRes = result.transformedResult()
     val res = plugins.beforeFinish(tRes)
     val filteredRes = res match {
       case Success => res
       case Failure(errors) =>
+        // Remove duplicate errors
         Failure(errors.distinctBy(failureFilterAndGroupingCriterion))
     }
     _verificationResult = Some(filteredRes)


### PR DESCRIPTION
The intention is to avoid reporting two errors via stdout that have the exact same message and position, which provides no value to the user. 
Currently, Silicon implements this itself, but Carbon does not. This PR adds an implementation in Silver to replace the one in Silicon (and in the process ensure that the filtering only happens when outputting to stdout, since the filtering can cause issues for frontends, see https://github.com/viperproject/silicon/issues/735).