### PR TITLE
Chopper: added logic for opaque functions

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -678,10 +678,10 @@ object Vertices {
   /** Represents a Viper method member. */
   case class Method private[Vertices](methodName: String) extends Vertex
 
-  /** Represents an opaque Viper function member without the body. */
+  /** Represents a Viper function member without the body. */
   case class FunctionSpec(functionName: String) extends Vertex
 
-  /** Represents an opaque Viper function member. */
+  /** Represents a Viper function member. */
   case class Function private[Vertices](functionName: String) extends Vertex
 
   /** Represents a Viper predicate member without the body. */

--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -788,7 +788,7 @@ trait Vertices {
       val funcs = {
         val fs = vertices.collect { case v: Function => functionTable(v.functionName) }.toSeq
         val stubs = vertices.collect { case v: FunctionSpec => val f = functionTable(v.functionName); f.copy(body = None)(f.pos, f.info, f.errT) }.toSeq
-        val filteredStubs = fs.filterNot(stub => stubs.exists(_.name == stub.name))
+        val filteredStubs = stubs.filterNot(stub => fs.exists(_.name == stub.name))
         fs ++ filteredStubs
       }
       val preds = {

--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -860,7 +860,7 @@ trait Edges { this: Vertices =>
           (f.pres ++ f.posts ++ f.formalArgs ++ f.result).flatMap(dependenciesToChildren(_, useVertex)) ++
           (f.info.getUniqueInfo[AnnotationInfo] match {
             case Some(ai) if ai.values.contains("opaque") => Seq()
-            case _ => Seq(useVertex -> defVertex) // for non opaque functions a use dependency is a def dependency
+            case _ => Seq(useVertex -> defVertex) // for non opaque functions, a use dependency is a def dependency
           })
 
       case _: ast.Field => dependenciesToChildren(member, defVertex)

--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -786,8 +786,8 @@ trait Vertices {
         (ms ++ filteredStubs).toSeq
       }
       val funcs = {
-        val fs = vertices.collect { case v: FunctionSpec => val f = functionTable(v.functionName); f.copy(body = None)(f.pos, f.info, f.errT) }.toSeq
-        val stubs = vertices.collect { case v: Function => functionTable(v.functionName) }.toSeq
+        val fs = vertices.collect { case v: Function => functionTable(v.functionName) }.toSeq
+        val stubs = vertices.collect { case v: FunctionSpec => val f = functionTable(v.functionName); f.copy(body = None)(f.pos, f.info, f.errT) }.toSeq
         val filteredStubs = fs.filterNot(stub => stubs.exists(_.name == stub.name))
         fs ++ filteredStubs
       }

--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -7,7 +7,7 @@
 package viper.silver.ast.utility.chopper
 
 import viper.silver.ast
-import viper.silver.ast.{AnnotationInfo, QuantifiedExp}
+import viper.silver.ast.AnnotationInfo
 import viper.silver.ast.utility.{Nodes, Visitor}
 
 import scala.annotation.tailrec
@@ -805,7 +805,10 @@ trait Vertices {
         val totalDs = (ds ++ fs.keys ++ as.keys).distinct
 
         totalDs.map { d =>
-          d.copy(functions = fs.getOrElse(d, Seq.empty), axioms = as.getOrElse(d, Seq.empty))(d.pos, d.info, d.errT)
+          d.copy(
+            functions = fs.getOrElse(d, Seq.empty),
+            axioms = as.getOrElse(d, Seq.empty),
+          )(d.pos, d.info, d.errT)
         }
       }
 
@@ -814,7 +817,7 @@ trait Vertices {
         functions = funcs,
         predicates = preds,
         fields = fields,
-        domains = domains
+        domains = domains,
       )(program.pos, program.info, program.errT)
     }
   }
@@ -885,7 +888,7 @@ trait Edges { this: Vertices =>
               case x => Nodes.subnodes(x)
             })(directUsages).flatten
 
-            def fromQuantifier(triggers: Seq[ast.Trigger], qexp: QuantifiedExp): Seq[Vertices.Vertex] = {
+            def fromQuantifier(triggers: Seq[ast.Trigger], qexp: ast.QuantifiedExp): Seq[Vertices.Vertex] = {
               val triggerUsages = triggers.map(usages)
               if (triggerUsages.exists(_.isEmpty)) {
                 // if there is a trigger w/o usages, we are conservative and

--- a/src/test/scala/ChopperTests.scala
+++ b/src/test/scala/ChopperTests.scala
@@ -231,7 +231,7 @@ class ChopperTests extends AnyFunSuite with Matchers with Inside {
     result.length shouldBe 2
     result shouldEqual Vector(
       ast.Program(Seq.empty, Seq.empty, Seq.empty, Seq(caller1, calleeStub), Seq.empty, Seq.empty)(),
-      ast.Program(Seq.empty, Seq.empty, Seq.empty, Seq(caller2, callee), Seq.empty, Seq.empty)(),
+      ast.Program(Seq.empty, Seq.empty, Seq.empty, Seq(callee, caller2), Seq.empty, Seq.empty)(),
     )
   }
 


### PR DESCRIPTION
Function vertices are now split into FunctionSpec vertices, representing a function spec, and Function vertices, representing the entire function. 

Dependencies have changed as follows:

- For non-opaque functions, we have FunctionSpec -> Function
- Function applications without reveal point to FunctionSpec
- Function applications with reveal point to Function

@Dspil @jcp19 Please check whether the chopper works as intended by connecting Gobra to it.