### PR TITLE
Parser changes for documentation generator

### DIFF
--- a/silver.sh
+++ b/silver.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+BASEDIR="$(realpath "$(dirname "$0")")"
+
+CP_FILE="$BASEDIR/silver_classpath.txt"
+
+if [ ! -f "$CP_FILE" ]; then
+    (cd "$BASEDIR"; sbt "export runtime:dependencyClasspath" | tail -n1 > "$CP_FILE")
+fi
+
+exec java -cp "$(cat "$CP_FILE")" viper.silver.SilverRunner "$@"

--- a/src/main/scala/viper/silver/SilverRunner.scala
+++ b/src/main/scala/viper/silver/SilverRunner.scala
@@ -1,0 +1,28 @@
+package viper.silver
+
+
+import scala.collection.immutable.ArraySeq
+import viper.silver.frontend.DefaultStates 
+import viper.silver.frontend.ViperAstProvider
+import viper.silver.logger.SilentLogger
+import viper.silver.reporter.NoopReporter
+
+
+object SilverRunner extends SilverRunnerInstance {
+  def main(args: Array[String]): Unit = {
+    runMain(args)
+  }
+}
+
+class SilverRunnerInstance extends ViperAstProvider(NoopReporter, SilentLogger().get) {
+  def runMain(args: Array[String]): Unit = {
+    var exitCode = 1 /* Only 0 indicates no error */
+
+    execute(ArraySeq.unsafeWrapArray(args))
+    
+    if (state >= DefaultStates.Translation) {
+      exitCode = 0
+    }
+    sys.exit(exitCode)
+  }
+}

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -827,7 +827,7 @@ class FastParser {
   // TODO does this handle positions correctly/consistently?
   // see also annotatedPrecondition, annotatedPostcondition
   def annotatedInvariant(implicit ctx : P[_]) : P[PSpecification[PKw.InvSpec]] =
-    P(annotation.rep(0) ~ invariant).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
+    NoCut(P(annotation.rep(0) ~ invariant)).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
             PSpecification[PKw.InvSpec](spec.k, spec.e, anns)(p) }.pos
 
   def invariant(implicit ctx : P[_]) : P[PSpecification[PKw.InvSpec]] =
@@ -944,7 +944,7 @@ class FastParser {
   })
 
   def annotatedPrecondition(implicit ctx : P[_]) : P[PSpecification[PKw.PreSpec]] =
-    P(annotation.rep(0) ~ precondition).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
+    NoCut(P(annotation.rep(0) ~ precondition)).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
             PSpecification[PKw.PreSpec](spec.k, spec.e, anns)(p) }.pos
 
   def precondition(implicit ctx : P[_]) : P[PSpecification[PKw.PreSpec]] =
@@ -952,7 +952,7 @@ class FastParser {
         PSpecification[PKw.PreSpec](kw, e)(p)}.pos | ParserExtension.preSpecification(ctx))
 
   def annotatedPostcondition(implicit ctx : P[_]) : P[PSpecification[PKw.PostSpec]] =
-    P(annotation.rep(0) ~ postcondition).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
+    NoCut(P(annotation.rep(0) ~ postcondition)).map{ case (anns, spec) => p: (FilePosition, FilePosition) =>
       PSpecification[PKw.PostSpec](spec.k, spec.e, anns)(p) }.pos
 
   def postcondition(implicit ctx : P[_]) : P[PSpecification[PKw.PostSpec]] =

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -33,7 +33,7 @@ object FastParserCompanion {
   implicit val whitespace = {
     import NoWhitespace._
     implicit ctx: ParsingRun[_] =>
-      NoTrace((("/*" ~ (!StringIn("*/") ~ AnyChar).rep ~ "*/") | ("//" ~ !StringIn("/") ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
+      NoTrace((("/*" ~ (!"*/" ~ AnyChar).rep ~ "*/") | ((("//" ~ !("/")) | "////") ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
   }
 
   def identStarts[$: P] = CharIn("A-Z", "a-z", "$_")

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -30,12 +30,10 @@ object FastParserCompanion {
       NoTrace((" " | "\t").rep)
   }
 
-  // TODO why is this duplicated? see FastParser below
   implicit val whitespace = {
     import NoWhitespace._
     implicit ctx: ParsingRun[_] =>
       NoTrace((("/*" ~ (!StringIn("*/") ~ AnyChar).rep ~ "*/") | ("//" ~ !StringIn("/") ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
-      // NoTrace((("/*" ~ (!StringIn("*/") ~ AnyChar).rep ~ "*/") | ("//" ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
   }
 
   def identStarts[$: P] = CharIn("A-Z", "a-z", "$_")
@@ -314,16 +312,7 @@ class FastParser {
   //////////////////////////
 
   import fastparse._
-  import FastParserCompanion.{ExtendedParsing, identContinues, identStarts, LeadingWhitespace, Pos, PositionParsing, reservedKw, reservedSym}
-
-
-  // TODO why is this duplicated? see FastParserCompanion
-  implicit val whitespace = {
-    import NoWhitespace._
-    implicit ctx: ParsingRun[_] =>
-      NoTrace((("/*" ~ (!StringIn("*/") ~ AnyChar).rep ~ "*/") | ("//" ~ !StringIn("/") ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
-      // NoTrace((("/*" ~ (!StringIn("*/") ~ AnyChar).rep ~ "*/") | ("//" ~ CharsWhile(_ != '\n').? ~ ("\n" | End)) | " " | "\t" | "\n" | "\r").rep)
-  }
+  import FastParserCompanion.{ExtendedParsing, identContinues, identStarts, LeadingWhitespace, Pos, PositionParsing, reservedKw, reservedSym, whitespace}
 
   implicit val lineCol: LineCol = new LineCol(this)
 

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -1694,9 +1694,14 @@ case class PMethodReturns(k: PKw.Returns, formalReturns: PGrouped.Paren[PDelimit
   */
 case class PAnnotationsPosition(annotations: Seq[PAnnotation], pos: (FilePosition, FilePosition))
 
-case class PAnnotation(at: PSym.At, key: PRawString, values: PGrouped.Paren[PDelimited[PStringLiteral, PSym.Comma]])(val pos: (Position, Position)) extends PNode with PPrettySubnodes {
+sealed trait PAnnotation extends PNode with PPrettySubnodes {
+  def key: PRawString
   override def pretty: String = super.pretty + "\n"
 }
+
+case class PAtAnnotation(at: PSym.At, key: PRawString, values: PGrouped.Paren[PDelimited[PStringLiteral, PSym.Comma]])(val pos: (Position, Position)) extends PNode with PAnnotation with PPrettySubnodes {}
+
+case class PDocAnnotation(tripleSlash: PSym.TripleSlash, docString: PRawString, key: PRawString = PRawString("doc")(NoPosition, NoPosition))(val pos: (Position, Position)) extends PAnnotation {}
 
 // Any unenclosed string (e.g. `hello`)
 case class PRawString(str: String)(val pos: (Position, Position)) extends PNode with PLeaf {

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -1668,7 +1668,7 @@ case class PFields(annotations: Seq[PAnnotation], field: PKw.Field, fields: PDel
   override def declares: Seq[PGlobalDeclaration] = fields.toSeq
 }
 
-case class PSpecification[+T <: PKw.Spec](k: PReserved[PKw.Spec], e: PExp)(val pos: (Position, Position)) extends PNode with PPrettySubnodes {
+case class PSpecification[+T <: PKw.Spec](k: PReserved[PKw.Spec], e: PExp, annotations: Seq[PAnnotation] = Seq())(val pos: (Position, Position)) extends PNode with PPrettySubnodes {
   override def pretty: String = "\n  " + super.pretty
 }
 

--- a/src/main/scala/viper/silver/parser/ParseAstKeyword.scala
+++ b/src/main/scala/viper/silver/parser/ParseAstKeyword.scala
@@ -321,6 +321,9 @@ object PSym {
   // Used for annotations
   case object At extends PSym("@") with PSymbolLang
   type At = PReserved[At.type]
+  // Used for documentation
+  case object TripleSlash extends PSym("///") with PSymbolLang
+  type TripleSlash = PReserved[TripleSlash.type]
   // Used for `new(*)`
   case object Star extends PSym("*") with PSymbolLang
   type Star = PReserved[Star.type]

--- a/src/main/scala/viper/silver/plugin/standard/doc/DocPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/doc/DocPlugin.scala
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2019 ETH Zurich.
+
+package viper.silver.plugin.standard.doc
+
+import viper.silver.plugin.SilverPlugin
+import viper.silver.ast.{Program, FilePosition, NoPosition, Position}
+import viper.silver.parser.{PProgram, PFieldDecl, PFields, PNode, PAnnotated, PAnnotatedExp,
+  PAnnotatedStmt, PAnnotation, PAtAnnotation, PDocAnnotation, PMethod, PFunction, PStringLiteral,
+  PAxiom, PSpecification, PRawString, PIdnRef, PPredicate, PDomain, PDomainFunction, Translator}
+import viper.silver.ast.utility.Visitor
+import upickle.default._
+import java.io._
+import viper.silver.frontend.SilFrontend
+import viper.silver.verifier.ParseReport
+
+case class DocReport(message: String, override val pos: Position)
+  extends ParseReport(message, pos) {
+  def fullId = "parser.documentation"
+  def readableMessage = message
+}
+
+class DocPlugin extends SilverPlugin {
+
+  case class DocNode(nodeType: String, info: NodeInfo, pos: (String, String), doc: String = "", children: Seq[DocNode]) {
+    /** @see [[Visitor.reduceTree()]] */
+    def reduceTree[T](f: (DocNode, Seq[T]) => T) = Visitor.reduceTree(this, DocNode.callSubnodes)(f)
+
+    /** @see [[Visitor.reduceWithContext()]] */
+    def reduceWithContext[C, R](context: C, enter: (DocNode, C) => C, combine: (DocNode, C, Seq[R]) => R) = {
+      Visitor.reduceWithContext(this, DocNode.callSubnodes)(context, enter, combine)
+    }
+  }
+
+  object DocNode {
+    def callSubnodes(n: DocNode): Seq[DocNode] = n.children
+    implicit lazy val rw: ReadWriter[DocNode] = macroRW
+  }
+
+  case class VarInfo(name: String, typ: String)
+  case class NodeInfo(name: String = "", typ: String = "",
+                      args: Seq[VarInfo] = Seq(),
+                      returns: Seq[VarInfo] = Seq(),
+                      misc: String = "")
+
+  object VarInfo {
+    implicit lazy val rw: ReadWriter[VarInfo] = macroRW
+  }
+  object NodeInfo {
+    implicit lazy val rw: ReadWriter[NodeInfo] = macroRW
+  }
+
+  /** Called after identifiers have been resolved but before the parse AST is
+    * translated into the normal AST.
+    *
+    * @param input
+    *   Parse AST
+    * @return
+    *   Modified Parse AST
+      */
+  override def beforeTranslate(input: PProgram): PProgram = {
+    val extractInfo: PNode => NodeInfo = {
+      // case n: PFields => Map("name" -> n.toString())
+      case PIdnRef(name) => NodeInfo(name)
+      case PFieldDecl(idndef, colon, typ) => NodeInfo(idndef.name, typ.toString())
+      case n: PMethod =>
+        NodeInfo(n.idndef.name, "", n.args.inner.toSeq.map(a => VarInfo(a.idndef.name, a.typ.toString())),
+                 n.returns match {
+                   case Some(returns) => returns.formalReturns.inner.toSeq.map(a => VarInfo(a.idndef.name, a.typ.toString()))
+                   case None => Seq() })
+      case n: PFunction =>
+        NodeInfo(n.idndef.name, n.resultType.toString(),
+                 n.args.inner.toSeq.map(a => VarInfo(a.idndef.name, a.typ.toString())))
+      case n: PPredicate => NodeInfo(n.idndef.name, "", n.args.inner.toSeq.map(a => VarInfo(a.idndef.name, a.typ.toString())))
+      case n: PDomain =>
+        NodeInfo(n.idndef.name, "",
+                 n.typVars match {
+                   case Some(typVars) => typVars.inner.toSeq.map(a => VarInfo("", a.idndef.name))
+                   case None => Seq() })
+      case n: PDomainFunction =>
+        NodeInfo(n.idndef.name, n.resultType.toString(),
+                 n.args.inner.toSeq.map(a =>
+                   VarInfo(a.name match {case Some(idndef) => idndef.name case None => ""}, a.typ.toString())),
+                 Seq(), n.unique match {case Some(kw) => kw.display.trim() case None => ""})
+      case n: PAxiom =>
+        NodeInfo(n.idndef match {case Some(id) => id.name case None => ""})
+      case n: PSpecification[_] => NodeInfo(n.k.rs.display.trim())
+      case _ => NodeInfo()
+    }
+
+    val extractPos: PNode => (String, String) = n => (n.pos._1.toString(), n.pos._2.toString())
+
+    val collectDocs: Seq[PAnnotation] => String = _.collect{ case k: PAtAnnotation if (k.key.str == "doc") => k.values.inner.toSeq.map(_.str)
+      case k: PDocAnnotation => Seq(k.docString.str) }.flatten.mkString("\n")
+    val translator: Translator = new Translator(input);
+    val extractDoc: PNode => String =
+      ({
+         case e: PAnnotatedExp => translator.extractAnnotation(e)._2.getOrElse("doc", Seq()).mkString("\n")
+         case s: PAnnotatedStmt => translator.extractAnnotationFromStmt(s)._2.getOrElse("doc", Seq()).mkString("\n")
+         case n: PAnnotated => collectDocs(n.annotations)
+         case n: PSpecification[_] => collectDocs(n.annotations)
+         case n: PAxiom => collectDocs(n.annotations)
+         case _ => ""
+       }: PNode => String)
+
+    val removeRoots: Seq[DocNode] => Seq[DocNode] = s => s.flatMap{
+      case t: DocNode if (t.nodeType == "*root*") => t.children
+      case n: DocNode => Seq(n)
+    }
+
+    val docTree = input.reduceTree(
+      (n: PNode, children: Seq[DocNode]) => {
+        val createDocNode = ((kind: String, n: PNode) =>
+          DocNode(kind, extractInfo(n), extractPos(n), extractDoc(n), removeRoots(children)))
+
+        n match {
+          case n: PIdnRef[_]                 => createDocNode("IdnRef", n)
+          case n: PFieldDecl                 => createDocNode("FieldDecl", n)
+          case n: PMethod                    => createDocNode("Method", n)
+          case n: PFunction                  => createDocNode("Function", n)
+          case n: PSpecification[_]          => createDocNode("Specification", n)
+          case n: PPredicate                 => createDocNode("Predicate", n)
+          case n: PDomain                    => createDocNode("Domain", n)
+          case n: PAxiom                     => createDocNode("Axiom", n)
+          case n: PDomainFunction            => createDocNode("DomainFunction", n)
+          case _                             => DocNode("*root*", NodeInfo(), ("", ""), "", removeRoots(children))
+        }
+      })
+
+    val json: String = write(docTree)
+    println(json)
+
+    PProgram(input.imported, input.members)(input.pos, DocReport(json, NoPosition) +: input.localErrors)
+  }
+}

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -8,7 +8,7 @@ package viper.silver.plugin.standard.termination
 
 import viper.silver.ast.utility.{Functions, ViperStrategy}
 import viper.silver.ast.utility.rewriter.{SimpleContext, Strategy, StrategyBuilder}
-import viper.silver.ast.{Applying, Assert, CondExp, CurrentPerm, Exp, FuncApp, Function, InhaleExhaleExp, MagicWand, Method, Node, Program, Unfolding, While}
+import viper.silver.ast.{Applying, Assert, CondExp, CurrentPerm, Exp, FilePosition, FuncApp, Function, InhaleExhaleExp, MagicWand, Method, Node, Program, Unfolding, While}
 import viper.silver.parser._
 import viper.silver.plugin.standard.predicateinstance.{PMarkerSymbol, PPredicateInstance}
 import viper.silver.plugin.standard.termination.transformation.Trafo
@@ -45,7 +45,8 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
    * decreases *
    */
   def decreases[$: P]: P[PSpecification[PDecreasesKeyword.type]] =
-    P((P(PDecreasesKeyword) ~ (decreasesWildcard | decreasesStar | decreasesTuple)) map (PSpecification.apply _).tupled).pos
+    P((P(PDecreasesKeyword) ~ (decreasesWildcard | decreasesStar | decreasesTuple)) map {
+        case (k, e) => p: (FilePosition, FilePosition) => PSpecification(k, e)(p) }).pos
   def decreasesTuple[$: P]: P[PDecreasesTuple] =
     P((exp.delimited(PSym.Comma) ~~~ condition.lw.?) map (PDecreasesTuple.apply _).tupled).pos
   def decreasesWildcard[$: P]: P[PDecreasesWildcard] = P((P(PWildcardSym) ~~~ condition.lw.?) map (PDecreasesWildcard.apply _).tupled).pos
@@ -239,7 +240,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
    * Remove decreases clauses from the AST and add them as information to the AST nodes
    */
   override def beforeVerify(input: Program): Program = {
-    // Prevent potentially unsafe (mutually) recursive function calls in function postcondtions
+    // Prevent potentially unsafe (mutually) recursive function calls in function postconditions
     // for all functions that don't have a decreases clause
     if (!deactivated) {
       lazy val cycles = Functions.findFunctionCyclesViaOptimized(input, func => func.body.toSeq)

--- a/src/test/scala/DocAnnotationTests.scala
+++ b/src/test/scala/DocAnnotationTests.scala
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2024 ETH Zurich.
+
+import org.scalatest.funsuite.AnyFunSuite
+import viper.silver.ast.Program
+import viper.silver.frontend._
+import viper.silver.logger.ViperStdOutLogger
+import viper.silver.reporter.StdIOReporter
+import viper.silver.parser.{PProgram, PAnnotatedExp, PWhile}
+
+class DocAnnotationTests extends AnyFunSuite {
+  object AstProvider extends ViperAstProvider(StdIOReporter(), ViperStdOutLogger("DocAnnotationTestsLogger").get) {
+    def setCode(code: String): Unit = {
+      _input = Some(code)
+    }
+
+    override def reset(input: java.nio.file.Path): Unit = {
+      if (state < DefaultStates.Initialized) sys.error("The translator has not been initialized.")
+      _state = DefaultStates.InputSet
+      _inputFile = Some(input)
+      /** must be set by [[setCode]] */
+      // _input = None
+      _errors = Seq()
+      _parsingResult = None
+      _semanticAnalysisResult = None
+      _verificationResult = None
+      _program = None
+      resetMessages()
+    }
+  }
+
+  def generatePAstAndAst(code: String): Option[(PProgram, Program)] = {
+    val code_id = code.hashCode.asInstanceOf[Short].toString
+    AstProvider.setCode(code)
+    AstProvider.execute(Seq("--ignoreFile", code_id))
+
+    if (AstProvider.errors.isEmpty) {
+      Some(AstProvider.parsingResult, AstProvider.translationResult)
+    } else {
+      AstProvider.logger.error(s"An error occurred while translating ${AstProvider.errors}")
+      None
+    }
+  }
+
+  test("Basic parsing of documentation") {
+    import viper.silver.ast._
+
+    val code =
+      """/// a field
+        |field f: Int
+        |/// P is a predicate
+        |predicate P(x: Int)
+        |
+        |/// a function
+        |function fun(x: Int): Int {
+        |  (x / 1 == x) ? 42 : 0
+        |}
+        |/// a second function
+        |function fun2(x: Int): Int
+        |    /// precondition
+        |    requires x > 0
+        |    /// post-
+        |    /// condition
+        |    ensures result > 0
+        |
+        |/// very important domain
+        |domain ImportantType {
+        |
+        |  /// this function
+        |  /// is crucial
+        |  function phi(ImportantType): Int
+        |
+        |  /// the only axiom
+        |  axiom {
+        |    /// documenting an expression
+        |    true
+        |  }
+        |}
+        |
+        |/// a macro
+        |define plus(a, b) (a+b)
+        |
+        |/// this is a method
+        |/// it does something
+        |method m(x: Ref, y: Ref)
+        |    /// this documents the first precondition
+        |    requires acc(x.f)
+        |    /// documentation of the second precondition
+        |    requires acc(y.f)
+        |{
+        |    var local: Bool
+        |
+        |    while (true)///the invariant
+        |      /// is always true
+        |      invariant true
+        |      /// termination
+        |      decreases x.f
+        |    {}
+        |
+        |}
+        |""".stripMargin
+
+    val pAst: PProgram = generatePAstAndAst(code).get._1
+
+    val fieldAnn = pAst.fields.head.annotations.head.values.inner.first.get.str
+    assert(fieldAnn == " a field")
+
+    val predicateAnnotation = pAst.predicates.head.annotations.head.values.inner.first.get.str
+    assert(predicateAnnotation == " P is a predicate")
+
+    val functionAnnotation = pAst.functions.head.annotations.head.values.inner.first.get.str
+    assert(functionAnnotation == " a function")
+
+    val fun2Annotation = pAst.functions(1).annotations.head.values.inner.first.get.str
+    val fun2PreAnnotations = pAst.functions(1).pres.head.annotations.map(_.values.inner.first.get.str)
+    val fun2PostAnnotations = pAst.functions(1).posts.head.annotations.map(_.values.inner.first.get.str)
+    assert(fun2Annotation == " a second function")
+    assert(fun2PreAnnotations == Seq(" precondition"))
+    assert(fun2PostAnnotations == Seq(" post-", " condition"))
+
+    val domainAnnotation = pAst.domains.head.annotations.head.values.inner.first.get.str
+    assert(domainAnnotation == " very important domain")
+
+    val domainFunctionAnnotations = pAst.domains.head.members.inner.funcs.head.annotations.map(_.values.inner.first.get.str)
+    assert(domainFunctionAnnotations == Seq(" this function", " is crucial"))
+
+    val axiomAnnotations = pAst.domains.head.members.inner.axioms.head.annotations.map(_.values.inner.first.get.str)
+    assert(axiomAnnotations == Seq(" the only axiom"))
+    val axiomExpAnnotations = pAst.domains.head.members.inner.axioms.head.exp.e.inner.asInstanceOf[PAnnotatedExp].annotation.values.inner.first.get.str
+    assert(axiomExpAnnotations == " documenting an expression")
+
+    val macroAnnotation = pAst.macros.head.annotations.head.values.inner.first.get.str
+    assert(macroAnnotation == " a macro")
+
+    val methodAnnotations = pAst.methods.head.annotations.map(_.values.inner.first.get.str)
+    assert(methodAnnotations == Seq(" this is a method", " it does something"))
+
+    val methodPreAnnotations = pAst.methods.head.pres.toSeq.map(_.annotations.head.values.inner.first.get.str)
+    assert(methodPreAnnotations == Seq(" this documents the first precondition", " documentation of the second precondition"))
+
+    val loopInvariantAnnotations = pAst.methods.head.body.get.ss.inner.inner.collect {
+          case (_, w: PWhile) => w.invs.toSeq.flatMap(_.annotations.map(_.values.inner.first.get.str))
+    }.flatten
+    assert(loopInvariantAnnotations == Seq("the invariant", " is always true", " termination"))
+  }
+}


### PR DESCRIPTION
This PR introduces changes to the parser for the documentation generator in development:
Comments starting with exactly three slashes are parsed as annotations with the key "doc". Moreover, annotations can now be put before specification keywords. Such annotations are put into a new `annotations`-field in the `PSpecification`-nodes in the parse AST. 
During translation into the Viper AST, specification annotations are pushed into the corresponding expression, as there are no specification nodes in the AST.
