### PR TITLE
Fixing crash in proof obligation expression computation

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -184,7 +184,7 @@ object Expressions {
           case _ => NoPosition
         }
         // Conditions for the current node.
-        val conds = n match {
+        val conds: Seq[Exp] = n match {
           case f@FieldAccess(rcv, _) => List(NeCmp(rcv, NullLit()(p))(p), FieldAccessPredicate(f, WildcardPerm()(p))(p))
           case f: FuncApp => prog.findFunction(f.funcname).pres
           case Div(_, q) => List(NeCmp(q, IntLit(0)(p))(p))
@@ -204,13 +204,13 @@ object Expressions {
         // Combine the conditions of the subnodes depending on what node we currently have.
         val finalSubConds = n match {
           case And(left, _) =>
-            val Seq(leftConds, rightConds) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
             reduceAndProofObs(left, leftConds, rightConds, p)
           case Implies(left, _) =>
-            val Seq(leftConds, rightConds) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
             reduceImpliesProofObs(left, leftConds, rightConds, p)
           case Or(left, _) =>
-            val Seq(leftConds, rightConds) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
             reduceOrProofObs(left, leftConds, rightConds, p)
           case CondExp(cond, _, _) =>
             val Seq(condConds, thenConds, elseConds, _) = nonTrivialSubConds

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -204,16 +204,16 @@ object Expressions {
         // Combine the conditions of the subnodes depending on what node we currently have.
         val finalSubConds = n match {
           case And(left, _) =>
-            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, Seq()) = nonTrivialSubConds
             reduceAndProofObs(left, leftConds, rightConds, p)
           case Implies(left, _) =>
-            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, Seq()) = nonTrivialSubConds
             reduceImpliesProofObs(left, leftConds, rightConds, p)
           case Or(left, _) =>
-            val Seq(leftConds, rightConds, _) = nonTrivialSubConds
+            val Seq(leftConds, rightConds, Seq()) = nonTrivialSubConds
             reduceOrProofObs(left, leftConds, rightConds, p)
           case CondExp(cond, _, _) =>
-            val Seq(condConds, thenConds, elseConds, _) = nonTrivialSubConds
+            val Seq(condConds, thenConds, elseConds, Seq()) = nonTrivialSubConds
             reduceCondExpProofObs(cond, condConds, thenConds, elseConds, p)
           case _ => subConds.flatten
         }


### PR DESCRIPTION
This code could crash because the list of subconditions for And, Or and Implies actually returns three lists of subnodes instead of two, which the code expected. This is because it return one list per subnode, and the subnodes include the type of the node, which is why there are three subnodes for binary operations.