### PR TITLE
Remove MissingOutput flag from test case conditionals2.vpr

### DIFF
--- a/src/test/resources/wands/regression/conditionals2.vpr
+++ b/src/test/resources/wands/regression/conditionals2.vpr
@@ -19,7 +19,6 @@ method test5a(x: Ref)
     //                       x.g |-> tg' # tf'' ? w : n
 
   //:: ExpectedOutput(assert.failed:insufficient.permission)
-  //:: MissingOutput(assert.failed:insufficient.permission, /silicon/issue/307/)
   assert acc(x.g, 1/1000)
 }
 


### PR DESCRIPTION
The PR viperproject/silicon#836 fixes an issue that was mentioned in Issue viperproject/silicon#307. For a 100% test result, the `MissingOutput` flag must be removed from the `conditionals2.vpr` test file.