### PR TITLE
Only simplify div and mod for positive arguments (like Carbon does)

### DIFF
--- a/src/test/scala/SimplifierTests.scala
+++ b/src/test/scala/SimplifierTests.scala
@@ -36,18 +36,21 @@ class SimplifierTests extends AnyFunSuite with Matchers {
   test("div") {
     simplify(Div(0, 0)()) should be(Div(0, 0)())
     simplify(Div(8, 2)()) should be(4: IntLit)
+    simplify(Div(-3, 2)()) should be(Div(-3, 2)())
+    simplify(Div(3, 2)()) should be(1: IntLit)
+    simplify(Div(3, -2)()) should be(Div(3, -2)())
   }
 
   test("mod") {
     simplify(Mod(0, 0)()) should be (Mod(0, 0)())
     simplify(Mod(8, 3)()) should be (2: IntLit)
     simplify(Mod(3, 8)()) should be (3: IntLit)
-    simplify(Mod(8, -3)()) should be (2: IntLit)
-    simplify(Mod(3, -8)()) should be (3: IntLit)
-    simplify(Mod(-8, 3)()) should be (1: IntLit)
-    simplify(Mod(-3, 8)()) should be (5: IntLit)
-    simplify(Mod(-8, -3)()) should be (1: IntLit)
-    simplify(Mod(-3, -8)()) should be (5: IntLit)
+    simplify(Mod(8, -3)()) should be (Mod(8, -3)())
+    simplify(Mod(3, -8)()) should be (Mod(3, -8)())
+    simplify(Mod(-8, 3)()) should be (Mod(-8, 3)())
+    simplify(Mod(-3, 8)()) should be (Mod(-3, 8)())
+    simplify(Mod(-8, -3)()) should be (Mod(-8, -3)())
+    simplify(Mod(-3, -8)()) should be (Mod(-3, -8)())
   }
 
   test("equality") {


### PR DESCRIPTION
This fixes #782. The Simplifier now behaves exactly like Carbon's optimization, see https://github.com/viperproject/carbon/pull/448.