### PR TITLE
Add argument to properly disallow nested macros

### DIFF
--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -751,7 +751,7 @@ class FastParser {
   }
 
   def stmt(allowDefine: Boolean = true)(implicit ctx : P[_]) : P[PStmt] = P(ParserExtension.newStmtAtStart(ctx) | annotatedStmt |
-    stmtReservedKw(allowDefine) | stmtBlock() |
+    stmtReservedKw(allowDefine) | stmtBlock(allowDefine) |
     assign | ParserExtension.newStmtAtEnd(ctx))
 
   def annotatedStmt(implicit ctx : P[_]): P[PStmt] = P((annotation ~ stmt()) map (PAnnotatedStmt.apply _).tupled).pos

--- a/src/test/resources/all/issues/silver/0786.vpr
+++ b/src/test/resources/all/issues/silver/0786.vpr
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+define outer_macro () {
+  //:: ExpectedOutput(parser.error)
+  { define inner_macro 42 }
+}
+
+method test()
+{
+  outer_macro()
+}


### PR DESCRIPTION
@JonasAlaif It looks to me as if the intention of the parser code is to disallow nested macro declarations (which would then prevent issues like #786), and the ``allowDefine`` value is just not properly forwarded in all cases in the ``stmt``rule. Or am I mistaken and this is somehow in purpose?