### PR TITLE
Allow domain axioms to use functions that have decreases clauses

### DIFF
--- a/src/main/scala/viper/silver/parser/Resolver.scala
+++ b/src/main/scala/viper/silver/parser/Resolver.scala
@@ -7,6 +7,7 @@
 package viper.silver.parser
 
 import viper.silver.FastMessaging
+import viper.silver.parser.PKw.Requires
 
 import scala.collection.mutable
 
@@ -685,8 +686,13 @@ case class TypeChecker(names: NameAnalyser) {
                           check(fd.typ)
                           fd.formalArgs foreach (a => check(a.typ))
                         }
-                        if (pfa.isDescendant[PAxiom] && pfn.pres.length != 0)
+                        if (pfa.isDescendant[PAxiom] && pfn.pres.toSeq.exists(pre => pre.k.rs == Requires)) {
+                          // A domain axiom, which must always be well-defined, is calling a function that has at least
+                          // one real precondition (i.e., not just a requires clause or something similar that's
+                          // temporarily represented as a precondition), which means that the call may not always be
+                          // well-defined. This is not allowed.
                           issueError(func, s"Cannot use function ${func.name}, which has preconditions, inside axiom")
+                        }
 
                       case pdf: PDomainFunction =>
                         val domain = pdf.domain

--- a/src/test/resources/all/issues/silicon/0847.vpr
+++ b/src/test/resources/all/issues/silicon/0847.vpr
@@ -1,0 +1,68 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+function f1(i: Int): Int
+    decreases i
+    requires i > -2
+{
+    i > 0 ? 1 + f1(i - 1) : 0
+}
+
+function f2(i: Int): Int
+    decreases i
+{
+    i > 0 ? 1 + f2(i - 1) : 0
+}
+
+function f3(i: Int): Int
+    decreases i
+    ensures result >= 0
+{
+    i > 0 ? 1 + f3(i - 1) : 0
+}
+
+function f4(i: Int): Int
+    ensures result >= 0
+    decreases _
+{
+    i > 0 ? 1 + f4(i - 1) : 0
+}
+
+function f5(i: Int): Int
+    requires i > -2
+    decreases i
+    ensures result >= 0
+{
+    i > 0 ? 1 + f5(i - 1) : 0
+}
+
+domain t {
+    function fAlias1(Int): Int
+    function fAlias2(Int): Int
+    function fAlias3(Int): Int
+    function fAlias4(Int): Int
+    function fAlias5(Int): Int
+
+    axiom {
+        //:: ExpectedOutput(typechecker.error)
+        forall i: Int :: f1(i) == fAlias1(i)
+    }
+
+    axiom {
+        forall i: Int :: f2(i) == fAlias2(i)
+    }
+
+    axiom {
+        forall i: Int :: f3(i) == fAlias3(i)
+    }
+
+    axiom {
+        forall i: Int :: f4(i) == fAlias4(i)
+    }
+
+    axiom {
+        //:: ExpectedOutput(typechecker.error)
+        forall i: Int :: f5(i) == fAlias5(i)
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/viperproject/silicon/issues/847, we now allow domain axioms to refer to non-domain functions that don't have any preconditions. However, currently, decreases clauses may be parsed as preconditions, and thus Viper rejects axioms that refer to functions that have no real preconditions but do have a decreases clause. 

This PR changes this behavior by ensuring that only preconditions with a requires-keyword are counted when checking if a function application inside an axiom is allowed. The reason we're checking for the presence of the requires-keyword and not the absence of a decreases-keyword or the presence of a decreases clause in the actual precondition expression is to avoid a dependency from Viper's type checker to the termination plugin.