### PR TITLE
Add block level message types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .cache
 project/project/**
 bin/**

--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -335,3 +335,21 @@ case class BenchmarkingMessage(category: String, payload: String) extends Messag
   override val name: String = "benchmarking_message"
   override val toString: String = s"Benchmarking message of type $category with payload $payload"
 }
+
+/** Reported when the block of a method CFG is reached. */
+case class BlockReachedMessage(methodName: String, label: String, pathId: Int) extends  Message {
+  override val toString: String = s"block_reached_message(methodName=$methodName, label=$label, pathId=$pathId)"
+  override val name: String = "block_reached_message"
+}
+
+/** Reported when the block of a method CFG failed to verify. */
+case class BlockFailureMessage(methodName: String, label: String, pathId: Int) extends  Message {
+  override val toString: String = s"block_failure_message(methodName=$methodName, label=$label, pathId=$pathId)"
+  override val name: String = "block_failure_message"
+}
+
+/** Reported when an execution path through the method has completed. */
+case class PathProcessedMessage(methodName: String, pathId: Int, result: String) extends  Message {
+  override val toString: String = s"path_processed_message(methodName=$methodName, pathId=$pathId, result=$result)"
+  override val name: String = "path_processed_message"
+}

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -117,6 +117,9 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
       case q: QuantifierInstantiationsMessage => csv_file.write(s"${q.toString}\n")
       case q: QuantifierChosenTriggersMessage => csv_file.write(s"${q.toString}\n")
       case t: VerificationTerminationMessage => csv_file.write(s"${t.toString}\n")
+      case r: BlockReachedMessage => csv_file.write(s"${r.toString}\n")
+      case f: BlockFailureMessage => csv_file.write(s"${f.toString}\n")
+      case p: PathProcessedMessage => csv_file.write(s"${p.toString}\n")
       case _ =>
         println( s"Cannot properly print message of unsupported type: $msg" )
     }
@@ -235,6 +238,9 @@ case class StdIOReporter(name: String = "stdout_reporter",
         //println( sm.text )
       case _: QuantifierInstantiationsMessage => // too verbose, do not print
       case _: QuantifierChosenTriggersMessage => // too verbose, do not print
+      case _: BlockReachedMessage => // too verbose, do not print
+      case _: BlockFailureMessage =>  // too verbose, do not print
+      case _: PathProcessedMessage =>  // too verbose, do not print
       case _: VerificationTerminationMessage =>
       case _: BenchmarkingMessage =>
       case _ =>


### PR DESCRIPTION
This PR aims to provide more granular progress reporting for the [Prusti-Assistant](https://github.com/viperproject/prusti-assistant) VS Code extension. It is part of a practical work under @Aurel300.

For this sake, three more message types are introduced.