### PR TITLE
Allow custom error message for assertion failures via @msg annotation

### DIFF
--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -399,6 +399,24 @@ object errors {
     val id = "assert.failed"
     val text = "Assert might fail."
 
+    val customMessageAnnotation = "msg"
+
+    def customErrorMessage = offendingNode.info.getUniqueInfo[AnnotationInfo] match {
+      case Some(ai) if ai.values.contains(customMessageAnnotation) && ai.values(customMessageAnnotation).nonEmpty =>
+        Some(ai.values("msg").head)
+      case _ => None
+    }
+
+    override def readableMessage: String = customErrorMessage match {
+      case Some(msg) => msg
+      case None => super.readableMessage
+    }
+
+    override def readableMessage(withId: Boolean, withPosition: Boolean): String = customErrorMessage match {
+      case Some(msg) => msg
+      case None => super.readableMessage(withId, withPosition)
+    }
+
     override def pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = AssertFailed(offendingNode.asInstanceOf[Assert], this.reason, this.cached)
     def withReason(r: ErrorReason) = AssertFailed(offendingNode, r, cached)


### PR DESCRIPTION
For example,

```
method test0(x: Ref)
{
   @msg("Custom error message") assert x != null
}
```
leads to Silicon output 
```
Silicon found 1 error in 2.83s:
  [0] Custom error message
```

Requested by @tdardinier.