### PR TITLE
Added missing variable declaration for checking InEx-Expressions in function postconditions 

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -98,7 +98,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
 
         if (proofMethodBody != EmptyStmt) {
           val proofMethod = Method(proofMethodName, f.formalArgs, Nil, f.pres, Nil,
-            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable))()))(info = f.info)
+            Option(Seqn(Seq(proofMethodBody), Seq(resultVariable, context.conditionInEx.get))()))(info = f.info)
 
           Seq(proofMethod)
         } else {

--- a/src/test/resources/all/issues/silicon/0883.vpr
+++ b/src/test/resources/all/issues/silicon/0883.vpr
@@ -1,3 +1,7 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
 field f: Int
 
 @moreJoins("2")

--- a/src/test/resources/all/issues/silicon/0886.vpr
+++ b/src/test/resources/all/issues/silicon/0886.vpr
@@ -1,0 +1,10 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+function foo(): Bool
+  decreases
+
+function bar(): Int
+  decreases
+  ensures [foo(), true]


### PR DESCRIPTION
To fix https://github.com/viperproject/silicon/issues/886.