### PR TITLE
Adapting termination plugin to new function permission semantics

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@
 //
 // Copyright (c) 2011-2019 ETH Zurich.
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -276,7 +276,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
       // if decreases checks are deactivated, only remove the decreases clauses from the program
       newProgram
     } else {
-      val trafo = new Trafo(newProgram, reportError)
+      val trafo = new Trafo(newProgram, reportError, if (config != null) config.respectFunctionPrePermAmounts() else false)
 
       val finalProgram = trafo.getTransformedProgram
       finalProgram

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -276,7 +276,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
       // if decreases checks are deactivated, only remove the decreases clauses from the program
       newProgram
     } else {
-      val trafo = new Trafo(newProgram, reportError, if (config != null) config.respectFunctionPrePermAmounts() else false)
+      val trafo = new Trafo(newProgram, reportError, config != null && config.respectFunctionPrePermAmounts())
 
       val finalProgram = trafo.getTransformedProgram
       finalProgram

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -133,8 +133,12 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
   }
 
   /**
-    * Given a method, removed all concrete permission amounts and replaces them with wildcard if they are positive,
+    * Given a method, removes all concrete permission amounts and replaces them with wildcard if they are positive,
     * otherwise with none.
+    * The transformation is only defined for language constructs that are expected to occur in methods generated
+    * to check function termination, i.e., it assumes there are no fold statements, no method calls, no permission
+    * introspection etc. It would be unsound in the presence of permission introspection, and possibly incomplete
+    * in the presence of method calls etc.
     */
   def removeConcretePermissionAmounts[N <: Node](n: N): N = n.transform{
     case u@Unfold(pap@PredicateAccessPredicate(loc, _)) =>

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/FunctionCheck.scala
@@ -34,7 +34,7 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
    *
    * @param f function
    */
-  protected def generateProofMethods(f: Function): Seq[Method] = {
+  protected def generateProofMethods(f: Function, respectFuncPermAmounts: Boolean): Seq[Method] = {
 
     getFunctionDecreasesSpecification(f.name) match {
       case DecreasesSpecification(None, _, _) => // no decreases tuple was defined, hence no proof methods required
@@ -125,7 +125,10 @@ trait FunctionCheck extends ProgramManager with DecreasesCheck with ExpTransform
         }
       } else Nil
     }
-    proofMethods.map(removeConcretePermissionAmounts)
+    if (respectFuncPermAmounts)
+      proofMethods
+    else
+      proofMethods.map(removeConcretePermissionAmounts)
   }
 
   /**

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/Trafo.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/Trafo.scala
@@ -18,7 +18,8 @@ import viper.silver.verifier.AbstractError
  * @param reportError Interface to report errors occurring during transformation.
  */
 final class Trafo(override val program: Program,
-                  override val reportError: AbstractError => Unit)
+                  override val reportError: AbstractError => Unit,
+                  val respectFuncPermAmounts: Boolean)
   extends ProgramManager with FunctionCheck with MethodCheck {
 
   private var transformedProgram: Option[Program] = None
@@ -29,7 +30,7 @@ final class Trafo(override val program: Program,
   def getTransformedProgram: Program = {
     transformedProgram.getOrElse({
 
-      val proofMethods: Seq[Method] = program.functions.flatMap(generateProofMethods)
+      val proofMethods: Seq[Method] = program.functions.flatMap(generateProofMethods(_, respectFuncPermAmounts))
       val newMethods: Seq[Method] = program.methods.map(transformMethod)
 
       val newProgram: Program = program.copy(methods = newMethods ++ proofMethods)(program.pos, program.info, program.errT)

--- a/src/test/resources/termination/functions/basic/permission_issues.vpr
+++ b/src/test/resources/termination/functions/basic/permission_issues.vpr
@@ -1,0 +1,89 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// Tests making sure that the termination checks correctly use the different permission semantics for functions
+
+field f: Int
+
+predicate P(x: Ref) {
+    acc(x.f)
+}
+
+function get(x: Ref, term: Bool): Int
+    requires acc(x.f)
+    decreases 0 if term
+{
+    x.f
+}
+
+function fn(r: Ref): Int
+  requires acc(r.f)
+  requires acc(r.f)
+  decreases 0
+{
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  fn(r)
+}
+
+function fnpost(r: Ref): Int
+  requires acc(r.f) && acc(r.f)
+  //:: ExpectedOutput(termination.failed:tuple.false)
+  ensures result > fnpost(r)
+  decreases 0
+{
+  1
+}
+
+function g(x: Ref, i: Int): Int
+    requires acc(P(x), 1/4)
+    decreases i
+{
+    i <= 0 ? 0 : unfolding P(x) in x.f + g(x, i - 1)
+}
+
+function gnt(x: Ref, i: Int): Int
+    requires acc(P(x), 1/4)
+    decreases i
+{
+    //:: ExpectedOutput(termination.failed:tuple.false)
+    i <= 0 ? 0 : unfolding P(x) in x.f + gnt(x, i)
+}
+
+
+function g2(x: Ref, b: Bool): Int
+    requires acc(P(x), b ? 1/4 : none)
+    decreases 0
+{
+    b ? unfolding P(x) in x.f : 1
+}
+
+function g3(x: Ref, b: Bool): Int
+    requires acc(P(x), b ? wildcard : none)
+    decreases 0
+{
+    b ? unfolding P(x) in get(x, true) : 1
+}
+
+function g3f(x: Ref, b: Bool): Int
+    requires acc(P(x), b ? wildcard : none)
+    decreases 0
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    b ? unfolding P(x) in get(x, false) : 1
+}
+
+function g4(x: Ref, b: Bool): Int
+    requires acc(P(x), wildcard)
+    decreases 0
+{
+    unfolding P(x) in get(x, true)
+}
+
+
+function g4f(x: Ref, b: Bool): Int
+    requires acc(P(x), wildcard)
+    decreases 0
+{
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
+    unfolding P(x) in get(x, false)
+}

--- a/src/test/resources/termination/functions/expressions/access.vpr
+++ b/src/test/resources/termination/functions/expressions/access.vpr
@@ -18,6 +18,7 @@ function test2(x: Ref): Bool
     decreases
     requires acc(x.f) && acc(x.f) && acc(x.g)
 {
+    //:: ExpectedOutput(termination.failed:termination.condition.false)
     nonTerminating(x)
 }
 


### PR DESCRIPTION
As @jcp19 noticed to my horror, the termination plugin that encodes termination checks for functions into methods needs to be adapted to account for the new permission semantics in functions, since otherwise the permissions have a different (wrong) meaning in the methods that check termination.

This PR does that by replacing positive permission amounts in the methods that check termination of functions by wildcards, which may have performance drawbacks but is the best we can do without modifying the language.

More concretely:
- All permission amounts in unfolds or unfoldings in function-check-methods are transformed to wildcards (since those have to be positive).
- All access predicates containing simple wildcards are left unchanged.
- All access predicates containing permission amounts that can statically seen to be positive are transformed to wildcards.
- All other access predicates ``acc(loc, p)`` are transformed to ``none < p' ==> acc(loc, wildcard)``, where ``p'`` is ``p`` with wildcards replaced by full permissions (since wildcards must not be used outside access predicates).