### PR TITLE
Support hovering over macro usages (lsp)

### DIFF
--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -750,7 +750,7 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
     } else {
       n.info.getUniqueInfo[AnnotationInfo] match {
         case Some(ai) if ai.values.nonEmpty =>
-          val docs = ai.values.map(v => char('@') <> v._1 <> parens(ssep(v._2.map(v => text(s"\"${v}\"")), text(", ")))).toSeq
+          val docs = ai.values.filter(v => v._1 != "expandedMacro").map(v => char('@') <> v._1 <> parens(ssep(v._2.map(v => text(s"\"${v}\"")), text(", ")))).toSeq
           Some(ssep(docs, if (breakLines) line else space))
         case _ => None
       }

--- a/src/main/scala/viper/silver/parser/MacroExpander.scala
+++ b/src/main/scala/viper/silver/parser/MacroExpander.scala
@@ -338,8 +338,11 @@ object MacroExpander {
       var bodyWithReplacedParams = replacer.execute[PNode](bodyWithRenamedVars, context)
       bodyWithReplacedParams = adaptPositions(bodyWithReplacedParams, pos)
 
-      // Return expanded macro's body
-      bodyWithReplacedParams
+      // Return expanded macro's body wrapped inside annotation
+      bodyWithReplacedParams match {
+        case b: PExp => PAnnotatedExp(PAnnotation(new PSym.At(PSym.At)(pos),PRawString("expandedMacro")(pos),PGrouped.impliedParen(PDelimited.empty))(pos),b)(pos)
+        case b: PStmt => PAnnotatedStmt(PAnnotation(new PSym.At(PSym.At)(pos),PRawString("expandedMacro")(pos),PGrouped.impliedParen(PDelimited.empty))(pos),b)(pos)
+      }
     }
 
     def ExpandMacroIfValid(macroCall: PNode, ctx: ContextA[PNode]): PNode = {

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -429,12 +429,12 @@ object errors {
   def PostconditionViolated(offendingNode: Exp, member: Contracted): PartialVerificationError =
     PartialVerificationError((reason: ErrorReason) => PostconditionViolated(offendingNode, member, reason))
 
-  case class PostconditionViolatedBranch(offendingNode: Exp, reason: ErrorReason, override val cached: Boolean = false) extends AbstractVerificationError {
+  case class PostconditionViolatedBranch(offendingNode: Exp, reason: ErrorReason, leftIsFatal: Boolean, rightIsFatal: Boolean, override val cached: Boolean = false) extends AbstractVerificationError {
     val id = "postcondition.violated.branch"
     val text = s"Branch fails."
 
-    def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = PostconditionViolatedBranch(offendingNode.asInstanceOf[Exp], this.reason, this.cached)
-    def withReason(r: ErrorReason) = PostconditionViolatedBranch(offendingNode, r, cached)
+    def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = PostconditionViolatedBranch(offendingNode.asInstanceOf[Exp], this.reason, leftIsFatal, rightIsFatal, this.cached)
+    def withReason(r: ErrorReason) = PostconditionViolatedBranch(offendingNode, r, leftIsFatal, rightIsFatal, cached)
   }
 
   case class FoldFailed(offendingNode: Fold, reason: ErrorReason, override val cached: Boolean = false) extends AbstractVerificationError {


### PR DESCRIPTION
Support hovering over macro usages (lsp) by wrapping macro body inside annotated node.