### PR TITLE
Consistency checks to forbid inhale-exhale-assertions in function preconditions and predicate bodies

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -161,6 +161,14 @@ object Consistency {
     })
   }
 
+  /** Checks that no inhale/exhale assertions occur in the given node. */
+  def checkNoInhaleExhale(e: Exp, locationDescription: String) : Seq[ConsistencyError] = {
+    e.deepCollect({
+      case ie: InhaleExhaleExp =>
+        ConsistencyError(s"Inhale-exhale expressions are not allowed in ${locationDescription}.", ie.pos)
+    })
+  }
+
   /** Check all properties required for a function body. */
   def checkFunctionBody(e: Exp) : Seq[ConsistencyError] = {
     var s = Seq.empty[ConsistencyError]


### PR DESCRIPTION
This PR adds consistency checks that forbid inhale-exhale assertions in predicate bodies and in function preconditions. Currently, Silicon raises an internal error when it encounters these (see https://github.com/viperproject/silicon/issues/271), whereas Carbon just accepts them.

I think the semantics is at the very least completely unclear and probably doesn't make sense at all, which is why this PR forbids this situation for now. However, this obviously needs to be discussed first, so this PR should not be merged before it's been discussed in a Viper meeting.