### PR TITLE
Fix pretty printer for termination measures

### DIFF
--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -10,6 +10,7 @@ import scala.language.implicitConversions
 import scala.collection.immutable.Queue
 import scala.collection.immutable.Queue.{empty => emptyDq}
 import viper.silver.ast._
+import viper.silver.plugin.standard.termination.DecreasesClause
 import viper.silver.verifier.DummyNode
 
 import scala.annotation.tailrec
@@ -528,13 +529,17 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       case Field(name, typ) =>
         text("field") <+> name <> ":" <+> show(typ)
       case Method(name, formalArgs, formalReturns, pres, posts, body) =>
+        // for the time being, the termination plugin transforms decreases clauses into preconditions or postconditions
+        val (terminationMeasuresInPres, actualPres) = pres.partition(exp => exp.isInstanceOf[DecreasesClause])
+        val (terminationMeasuresInPosts, actualPosts) = posts.partition(exp => exp.isInstanceOf[DecreasesClause])
         group(text("method") <+> name <> nest(defaultIndent, parens(showVars(formalArgs))) <> {
           if (formalReturns.isEmpty) nil
           else nest(defaultIndent, line <> "returns" <+> parens(showVars(formalReturns)))
         }) <>
           nest(defaultIndent,
-            showContracts("requires", pres) <>
-            showContracts("ensures", posts)
+            showContracts("requires", actualPres) <>
+              showContracts("ensures", actualPosts) <>
+              showDecreasesClauses(terminationMeasuresInPres ++ terminationMeasuresInPosts)
           ) <>
           line <> (
           body match {
@@ -549,11 +554,15 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
           case Some(exp) => braces(nest(defaultIndent, line <> show(exp)) <> line)
         })
       case Function(name, formalArgs, typ, pres, posts, optBody) =>
+        // for the time being, the termination plugin transforms decreases clauses into preconditions or postconditions
+        val (terminationMeasuresInPres, actualPres) = pres.partition(exp => exp.isInstanceOf[DecreasesClause])
+        val (terminationMeasuresInPosts, actualPosts) = posts.partition(exp => exp.isInstanceOf[DecreasesClause])
         text("function") <+> name <> nest(defaultIndent, parens(showVars(formalArgs))) <>
           ":" <+> show(typ) <>
           nest(defaultIndent,
-            showContracts("requires", pres) <>
-              showContracts("ensures", posts)
+            showContracts("requires", actualPres) <>
+              showContracts("ensures", actualPosts) <>
+              showDecreasesClauses(terminationMeasuresInPres ++ terminationMeasuresInPosts)
           ) <>
           line <>
           (optBody match {
@@ -574,6 +583,11 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
       line <> name <+> uninitialized
     else
       lineIfSomeNonEmpty(contracts) <> ssep(contracts.map(c => text(name) <+> nest(defaultIndent, show(c))), line)
+  }
+
+  /** Shows a list of termination measures. */
+  def showDecreasesClauses(measures: Seq[Exp]): Cont = {
+      lineIfSomeNonEmpty(measures) <> ssep(measures.map(c => nest(defaultIndent, show(c))), line)
   }
 
   /** Returns `n` lines if at least one element of `s` is non-empty, and an empty document otherwise. */
@@ -692,11 +706,11 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
           ssep((if (locals == null) Nil else locals map (text("var") <+> showVar(_))) ++ (stmtsToShow map show), line)
         }
       case While(cond, invs, body) =>
+        val (terminationMeasures, actualInvs) = invs.partition(exp => exp.isInstanceOf[DecreasesClause])
         text("while") <+> parens(show(cond)) <>
-          nest(defaultIndent,
-            showContracts("invariant", invs)
-          ) <+> lineIfSomeNonEmpty(invs) <>
-          showBlock(body)
+          nest(defaultIndent, showContracts("invariant", actualInvs) <> showDecreasesClauses(terminationMeasures)) <+>
+            lineIfSomeNonEmpty(invs) <>
+            showBlock(body)
       case If(cond, thn, els) =>
         text("if") <+> parens(show(cond)) <+> showBlock(thn) <> showElse(els)
       case Label(name, invs) =>

--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstanceASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstanceASTExtension.scala
@@ -23,7 +23,7 @@ case class PredicateInstance(p: String, args: Seq[Exp])(override val pos: Positi
   override def verifyExtExp(): VerificationResult = ???
 
   override def prettyPrint: PrettyPrintPrimitives#Cont =
-    text("@") <> text(p) <> parens(ssep(args map show, char (',') <> space))
+    text(p) <> parens(ssep(args map show, char (',') <> space))
 
   override lazy val check: Seq[ConsistencyError] = {
     args.flatMap(Consistency.checkPure)

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationASTExtension.scala
@@ -7,7 +7,7 @@
 package viper.silver.plugin.standard.termination
 
 import viper.silver.ast._
-import viper.silver.ast.pretty.FastPrettyPrinter.{ContOps, char, space, ssep, text, toParenDoc}
+import viper.silver.ast.pretty.FastPrettyPrinter.{ContOps, char, nil, space, ssep, text, toParenDoc}
 import viper.silver.ast.pretty.PrettyPrintPrimitives
 import viper.silver.ast.utility.Consistency
 import viper.silver.verifier.{ConsistencyError, Failure, VerificationResult}
@@ -50,8 +50,10 @@ case class DecreasesTuple(tupleExpressions: Seq[Exp] = Nil, override val conditi
 
   override val typ: Type = Bool
 
-  override lazy val prettyPrint: PrettyPrintPrimitives#Cont =
-    text("decreases") <> space <> ssep(tupleExpressions map (toParenDoc(_)), char(',') <> space)
+  override lazy val prettyPrint: PrettyPrintPrimitives#Cont = {
+    text("decreases") <>
+      (if (tupleExpressions.nonEmpty) space <> ssep(tupleExpressions map (toParenDoc(_)), char(',') <> space) else nil)
+  }
 
   override val extensionSubnodes: Seq[Node] = tupleExpressions ++ condition
 


### PR DESCRIPTION
While pretty printing the Viper files emitted by Gobra, I found two issues with the pretty printer of termination measures:
1. because termination measures are converted into preconditions (posts are also supported, IIRC) by the termination plugin, the pretty printer prints decreases clauses as `requires decreases X` instead of `decreases X`
2. When the termination measure is a predicate instance, the PredicateInstance plugin will insert an "@" before the name of the predicate in the termination measure

For a concrete example, viper pretty prints
```
function IsDuplicableMem(thisItf: Tuple2[Ref, Types]): Bool
  requires decreases @ErrorMem(thisItf)
```
instead of
```
function IsDuplicableMem(thisItf: Tuple2[Ref, Types]): Bool
  decreases ErrorMem(thisItf)
```

PS: I don't understand why predicate instances where being printed with a "@" in the first place, and as far as I can tell, no one relies on this behaviour. Maybe @mschwerhoff knows why.