### PR TITLE
Add support for chopping programs before the Termination plugin runs

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -73,7 +73,7 @@ trait ChopperLike { this: ViperGraphs with Cut =>
             penalty: Penalty[Vertices.Vertex] = Penalty.Default,
             beforeTerminationPlugin: Boolean = false,
           ): Vector[ast.Program] = {
-    chopWithMetrics(choppee)(selection, bound, penalty)._1
+    chopWithMetrics(choppee)(selection, bound, penalty, beforeTerminationPlugin)._1
   }
 
   /**

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -169,7 +169,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
     // Check if the program contains any domains that define decreasing and bounded functions that do *not* have the expected names.
     for (d <- input.domains) {
       val name = d.idndef.name
-      val typeName = if (name.endsWith("WellFoundedOrder"))
+      val typeName = if (name.endsWith(TerminationPlugin.wellFoundedOrderDomainSuffix))
         Some(name.substring(0, name.length - 16))
       else
         None
@@ -411,4 +411,8 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
     case Unfolding(_, exp) => Seq(exp)
     case CurrentPerm(_) => Nil
   })
+}
+
+object TerminationPlugin {
+  val wellFoundedOrderDomainSuffix = "WellFoundedOrder"
 }

--- a/src/test/scala/ChopperTests.scala
+++ b/src/test/scala/ChopperTests.scala
@@ -235,6 +235,23 @@ class ChopperTests extends AnyFunSuite with Matchers with Inside {
     )
   }
 
+  test("WellFoundedOrders are kept for programs that still have termination measures") {
+    val intVarDecl = ast.LocalVarDecl("i", ast.Int)()
+    val function = ast.Function("functionA", Seq(intVarDecl), ast.Bool, Seq.empty, Seq.empty, None)()
+    val domainName = "IntWellFoundedOrder"
+    val decreasingFn = ast.DomainFunc(
+      "decreasing",
+      Seq(ast.LocalVarDecl("l1", ast.Int)(), ast.LocalVarDecl("l2", ast.Int)()),
+      ast.Bool,
+    )(domainName = domainName)
+    val boundedFn = ast.DomainFunc("bounded", Seq(ast.LocalVarDecl("l", ast.Int)()), ast.Bool)(domainName = domainName)
+    val wfoDomain = ast.Domain(domainName, Seq(decreasingFn, boundedFn), Seq())()
+    val program = ast.Program(Seq(wfoDomain), Seq.empty, Seq(function), Seq.empty, Seq.empty, Seq.empty)()
+    val result = Chopper.chop(program)(bound = Some(5), penalty = Penalty.DefaultWithoutForcedMerge, beforeTerminationPlugin = true)
+    result.length shouldBe 1
+    result.head shouldEqual program
+  }
+
   // SCC tests
 
   test("SCC with singleton graph") {


### PR DESCRIPTION
Currently, the chopper expects to receive code after all plugins have executed. Unfortunately, this requirement is often impractical, especially when one uses the `SilFrontend` API, which makes it impractical to access the program after all plugins have run. This PR extends the chopper to support code prior to the termination plugin. Note that the chopper may also work before running other plugins, like the `refute` plugin, but this needs to be checked on a per-plugin basis.