### PR TITLE
Fixes missing positional information in error reason caused by PredicateInstance plugin

### DIFF
--- a/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/predicateinstance/PredicateInstancePlugin.scala
@@ -64,11 +64,13 @@ class PredicateInstancePlugin(@unused reporter: viper.silver.reporter.Reporter,
         case None =>
           val piFunctionName = s"PI_${predicateInstance.p}"
           val pred = program.findPredicate(predicateInstance.p)
+          val predicateAccess = PredicateAccess(pred.formalArgs.map(_.localVar), pred.name)(predicateInstance.pos, predicateInstance.info, predicateInstance.errT)
+          val predicateAccessPredicate = PredicateAccessPredicate(predicateAccess, Some(WildcardPerm()()))(predicateInstance.pos, predicateInstance.info, predicateInstance.errT)
           val newPIFunction =
             Function(piFunctionName,
               pred.formalArgs,
               DomainType(PredicateInstanceDomain.get, Map()),
-              Seq(PredicateAccessPredicate(PredicateAccess(pred.formalArgs.map(_.localVar), pred.name)(), Some(WildcardPerm()()))(predicateInstance.pos, predicateInstance.info, predicateInstance.errT)),
+              Seq(predicateAccessPredicate),
               Seq(),
               None
             )(PredicateInstanceDomain.get.pos, PredicateInstanceDomain.get.info)


### PR DESCRIPTION
If a predicate instance is used as a termination measure but there are insufficient permissions for this predicate instance, Viper creates a `PredicateInstanceNoAccess` error with that predicate instance as a reason.
While the PredicateInstance plugin propagates positional information to the translated PredicateAccessPredicate, it did not do so for the PredicateAccess contained therein. However, it seems that Viper uses the PredicateAccess as offending node and this PR adapts the PredicateInstance plugin to use the same positional information for both, the generated PredicateAccessPredicate _and_ PredicateAccess.