### PR TITLE
Deterministic Plugin Execution Order

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -63,10 +63,12 @@ trait SilFrontend extends DefaultFrontend {
     val pluginsArg: Option[String] = if (_config != null) {
       // concat defined plugins and default plugins
       // we do not use sets here as the order of plugins matters!
-      val pluginClasses = (if (_config.enableSmokeDetection()) Seq(smokeDetectionPlugin) else Seq.empty) ++
-        (if (_config.disableDefaultPlugins()) Set.empty else defaultPlugins) ++
+      // note that the smoke detection plugin requires the refute plugin
+      val smokeDetectionAndDependencies = if (_config.enableSmokeDetection()) Seq(smokeDetectionPlugin, refutePlugin) else Seq.empty
+      val pluginClasses = smokeDetectionAndDependencies ++
+        // filter `defaultPlugins` to avoid duplicates
+        (if (_config.disableDefaultPlugins()) Seq.empty else defaultPlugins.filterNot(p => smokeDetectionAndDependencies.contains(p))) ++
         _config.plugin.toOption.toSeq
-      println(s"plugins: $pluginClasses")
 
       if (pluginClasses.isEmpty) {
         None

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -72,7 +72,7 @@ trait SilFrontend extends DefaultFrontend {
 
       val duplicatePluginClasses = pluginClasses.groupBy(identity).collect { case (x, instances) if instances.length > 1 => x }
       if (duplicatePluginClasses.nonEmpty) {
-        reporter report ConfigurationWarning(s"The following plugins will be executed multiple times, which is most likely a bug: ${duplicatePluginClasses.mkString(", ")}.")
+        reporter report ConfigurationWarning(s"The following plugins will be executed multiple times, which is most likely a configuration mistake: ${duplicatePluginClasses.mkString(", ")}.")
       }
 
       if (pluginClasses.isEmpty) {

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -68,7 +68,7 @@ trait SilFrontend extends DefaultFrontend {
       val pluginClasses = smokeDetectionAndDependencies ++
         // filter `defaultPlugins` to avoid duplicates
         (if (_config.disableDefaultPlugins()) Seq.empty else defaultPlugins.filterNot(p => smokeDetectionAndDependencies.contains(p))) ++
-        _config.plugin.toOption.toSeq
+        _config.plugin.toOption.map(_.split(":").toSeq).getOrElse(Seq.empty)
 
       val duplicatePluginClasses = pluginClasses.groupBy(identity).collect { case (x, instances) if instances.length > 1 => x }
       if (duplicatePluginClasses.nonEmpty) {

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -62,14 +62,16 @@ trait SilFrontend extends DefaultFrontend {
   def resetPlugins(): Unit = {
     val pluginsArg: Option[String] = if (_config != null) {
       // concat defined plugins and default plugins
-      val list = (if (_config.enableSmokeDetection()) Set(smokeDetectionPlugin, refutePlugin) else Set()) ++
-        (if (_config.disableDefaultPlugins()) Set() else defaultPlugins) ++
-        _config.plugin.toOption.toSet
+      // we do not use sets here as the order of plugins matters!
+      val pluginClasses = (if (_config.enableSmokeDetection()) Seq(smokeDetectionPlugin) else Seq.empty) ++
+        (if (_config.disableDefaultPlugins()) Set.empty else defaultPlugins) ++
+        _config.plugin.toOption.toSeq
+      println(s"plugins: $pluginClasses")
 
-      if (list.isEmpty) {
+      if (pluginClasses.isEmpty) {
         None
       } else {
-        Some(list.mkString(":"))
+        Some(pluginClasses.mkString(":"))
       }
     } else {
       None

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -70,6 +70,11 @@ trait SilFrontend extends DefaultFrontend {
         (if (_config.disableDefaultPlugins()) Seq.empty else defaultPlugins.filterNot(p => smokeDetectionAndDependencies.contains(p))) ++
         _config.plugin.toOption.toSeq
 
+      val duplicatePluginClasses = pluginClasses.groupBy(identity).collect { case (x, instances) if instances.length > 1 => x }
+      if (duplicatePluginClasses.nonEmpty) {
+        reporter report ConfigurationWarning(s"The following plugins will be executed multiple times, which is most likely a bug: ${duplicatePluginClasses.mkString(", ")}.")
+      }
+
       if (pluginClasses.isEmpty) {
         None
       } else {

--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -283,6 +283,10 @@ case class ConfigurationConfirmation(override val text: String) extends SimpleMe
   override val name: String = "configuration_confirmation"
 }
 
+case class ConfigurationWarning(override val text: String) extends SimpleMessage(text) {
+  override val name: String = "configuration_warning"
+}
+
 case class AnnotationWarning(override val text: String) extends SimpleMessage(text) {
   override val name: String = "annotation_warning"
 }


### PR DESCRIPTION
This PR ensures that plugins are executed in the same order as specified by the user. Since the refute plugin is part of the default plugins, we have to take extra care not to execute the same plugin multiple times.