### PR TITLE
Making reporters plugin aware

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -75,6 +75,10 @@ trait SilFrontend extends DefaultFrontend {
       None
     }
     _plugins = SilverPluginManager(pluginsArg)(reporter, logger, _config, fp)
+    reporter match {
+      case par: PluginAwareReporter => par.setPluginManager(Some(_plugins))
+      case _ =>
+    }
   }
 
   /**

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -205,9 +205,7 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
 
       // These get reported without being transformed by any plugins, it would be an issue if we printed them to STDOUT.
       case EntitySuccessMessage(_, _, _, _) =>    // FIXME Currently, we only print overall verification results to STDOUT.
-        println(msg)
       case EntityFailureMessage(_, _, _, _, _) =>    // FIXME Currently, we only print overall verification results to STDOUT.
-        println(msg)
       case BranchFailureMessage(_, _, _, _) =>    // FIXME Currently, we only print overall verification results to STDOUT.
       case ConfigurationConfirmation(_) =>     // TODO  use for progress reporting
         //println( s"Configuration confirmation: $text" )

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -35,7 +35,10 @@ trait PluginAwareReporter extends Reporter {
     plugins match {
       case None => doReport(msg)
       case Some(plgns) =>
-        val transformed = msg match {
+        msg match {
+          // We transform only EntrySuccessMessage and EntityFailureMessage, not OverallSuccessMessage and
+          // OverallFailureMessage here, since the overall verification results are already transformed by the verifier
+          // *before* reporting the corresponding message.
           case esm: EntitySuccessMessage =>
             val newResult = plgns.mapEntityVerificationResult(esm.concerning, Success)
             doReport(VerificationResultMessage(esm.verifier, esm.concerning, esm.verificationTime, newResult))
@@ -44,7 +47,6 @@ trait PluginAwareReporter extends Reporter {
             doReport(VerificationResultMessage(efm.verifier, efm.concerning, efm.verificationTime, newResult))
           case m => doReport(m)
         }
-    }
     }
   }
 

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -31,7 +31,7 @@ trait PluginAwareReporter extends Reporter {
     plugins = pm
   }
 
-  override def report(msg: Message): Unit = {
+  final override def report(msg: Message): Unit = {
     if (plugins.isEmpty)
       return doReport(msg)
     msg match {

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -25,7 +25,7 @@ object NoopReporter extends Reporter {
 
 trait PluginAwareReporter extends Reporter {
 
-  var plugins: Option[SilverPluginManager] = None
+  protected var plugins: Option[SilverPluginManager] = None
 
   def setPluginManager(pm: Option[SilverPluginManager]): Unit = {
     plugins = pm

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -32,16 +32,19 @@ trait PluginAwareReporter extends Reporter {
   }
 
   final override def report(msg: Message): Unit = {
-    if (plugins.isEmpty)
-      return doReport(msg)
-    msg match {
-      case esm: EntitySuccessMessage =>
-        val newResult = plugins.get.mapEntityVerificationResult(esm.concerning, Success)
-        doReport(VerificationResultMessage(esm.verifier, esm.concerning, esm.verificationTime, newResult))
-      case efm: EntityFailureMessage =>
-        val newResult = plugins.get.mapEntityVerificationResult(efm.concerning, efm.result)
-        doReport(VerificationResultMessage(efm.verifier, efm.concerning, efm.verificationTime, newResult))
-      case m => doReport(m)
+    plugins match {
+      case None => doReport(msg)
+      case Some(plgns) =>
+        val transformed = msg match {
+          case esm: EntitySuccessMessage =>
+            val newResult = plgns.mapEntityVerificationResult(esm.concerning, Success)
+            doReport(VerificationResultMessage(esm.verifier, esm.concerning, esm.verificationTime, newResult))
+          case efm: EntityFailureMessage =>
+            val newResult = plgns.mapEntityVerificationResult(efm.concerning, efm.result)
+            doReport(VerificationResultMessage(efm.verifier, efm.concerning, efm.verificationTime, newResult))
+          case m => doReport(m)
+        }
+    }
     }
   }
 


### PR DESCRIPTION
Adding a new trait ``PluginAwareReporter`` and modifying all existing ``Reporter`` implementations to implement it.

The ``SilFrontend``, when given a ``PluginAwareReporter``, informs it about the current plugins s.t. the reporter can let the plugins transform ``EntitySuccessMessage``s and ``EntityFailureMessages``. Currently, these are not being transformed at all, which is why entity messages can report incorrect results.

The ``ActorReporter`` in ViperServer will have to be modified to implement the new trait as well. 