### PR TITLE
Fixing issue #849 

### DIFF
--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -1297,5 +1297,6 @@ trait ExtensionExp extends Exp {
     * Sample implementation would be text("old") <> parens(show(e)) for pretty-printing an old-expression.*/
   def prettyPrint: PrettyPrintPrimitives#Cont
 
-  def validTrigger(p: Program): Boolean = false
+  /** Defines whether this expression can be used as a trigger. Defaults to false. */
+  def extensionIsValidTrigger(): Boolean = false
 }

--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -1296,4 +1296,6 @@ trait ExtensionExp extends Exp {
   /** Pretty printing functionality as defined for other nodes in class FastPrettyPrinter.
     * Sample implementation would be text("old") <> parens(show(e)) for pretty-printing an old-expression.*/
   def prettyPrint: PrettyPrintPrimitives#Cont
+
+  def validTrigger(p: Program): Boolean = false
 }

--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -1290,13 +1290,20 @@ sealed trait Lhs extends Exp
   * reach the backend verifiers. */
 trait ExtensionExp extends Exp {
   def extensionIsPure: Boolean
+
   def extensionSubnodes: Seq[Node]
+
   def typ: Type
+
   def verifyExtExp(): VerificationResult
+
   /** Pretty printing functionality as defined for other nodes in class FastPrettyPrinter.
-    * Sample implementation would be text("old") <> parens(show(e)) for pretty-printing an old-expression.*/
+    * Sample implementation would be text("old") <> parens(show(e)) for pretty-printing an old-expression. */
   def prettyPrint: PrettyPrintPrimitives#Cont
 
   /** Defines whether this expression can be used as a trigger. Defaults to false. */
   def extensionIsValidTrigger(): Boolean = false
+
+  /** Defines whether this expression is forbidden from occurring *anywhere* in a trigger. Defaults to true.  */
+  def extensionIsForbiddenInTrigger(): Boolean = true
 }

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -270,8 +270,8 @@ object Consistency {
       case Old(nested) => validTrigger(nested, program) // case corresponds to OldTrigger node
       case LabelledOld(nested, _) => validTrigger(nested, program)
       case ee: ExtensionExp => ee.extensionIsValidTrigger()
-      case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.existsDefined {case _: ForbiddenInTrigger => })
-      case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.existsDefined { case _: ForbiddenInTrigger => }
+      case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.existsDefined(Expressions.isForbiddenInTrigger))
+      case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.existsDefined(Expressions.isForbiddenInTrigger)
       case _ => false
     }
   }

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -266,8 +266,7 @@ object Consistency {
     e match {
       case Old(nested) => validTrigger(nested, program) // case corresponds to OldTrigger node
       case LabelledOld(nested, _) => validTrigger(nested, program)
-      case ee: ExtensionExp =>
-        ee.validTrigger(program)
+      case ee: ExtensionExp => ee.extensionIsValidTrigger()
       case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.existsDefined {case _: ForbiddenInTrigger => })
       case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.existsDefined { case _: ForbiddenInTrigger => }
       case _ => false

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -266,6 +266,8 @@ object Consistency {
     e match {
       case Old(nested) => validTrigger(nested, program) // case corresponds to OldTrigger node
       case LabelledOld(nested, _) => validTrigger(nested, program)
+      case ee: ExtensionExp =>
+        ee.validTrigger(program)
       case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.existsDefined {case _: ForbiddenInTrigger => })
       case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.existsDefined { case _: ForbiddenInTrigger => }
       case _ => false

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -270,8 +270,8 @@ object Consistency {
       case Old(nested) => validTrigger(nested, program) // case corresponds to OldTrigger node
       case LabelledOld(nested, _) => validTrigger(nested, program)
       case ee: ExtensionExp => ee.extensionIsValidTrigger()
-      case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.existsDefined(Expressions.isForbiddenInTrigger))
-      case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.existsDefined(Expressions.isForbiddenInTrigger)
+      case wand: MagicWand => wand.subexpressionsToEvaluate(program).forall(e => !e.exists(Expressions.isForbiddenInTrigger))
+      case _ : PossibleTrigger | _: FieldAccess | _: PredicateAccess => !e.exists(Expressions.isForbiddenInTrigger)
       case _ => false
     }
   }

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -295,6 +295,11 @@ object Expressions {
     leftConds ++ guardedRightConds
   }
 
+  def isForbiddenInTrigger: PartialFunction[Node, Unit] = {
+    case _: ForbiddenInTrigger =>
+    case ee: ExtensionExp if ee.extensionIsForbiddenInTrigger() =>
+  }
+
   /** See [[viper.silver.ast.utility.Triggers.TriggerGeneration.generateTriggerSetGroups]] */
   def generateTriggerGroups(exp: QuantifiedExp, tg: TriggerGeneration = DefaultTriggerGeneration): Seq[(Seq[tg.TriggerSet], Seq[LocalVarDecl])] = {
     tg.generateTriggerSetGroups(exp.variables map (_.localVar), exp.exp)

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -295,9 +295,10 @@ object Expressions {
     leftConds ++ guardedRightConds
   }
 
-  def isForbiddenInTrigger: PartialFunction[Node, Unit] = {
-    case _: ForbiddenInTrigger =>
-    case ee: ExtensionExp if ee.extensionIsForbiddenInTrigger() =>
+  def isForbiddenInTrigger(n: Node): Boolean = n match {
+    case _: ForbiddenInTrigger => true
+    case ee: ExtensionExp => ee.extensionIsForbiddenInTrigger()
+    case _ => false
   }
 
   /** See [[viper.silver.ast.utility.Triggers.TriggerGeneration.generateTriggerSetGroups]] */

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -39,7 +39,7 @@ object Triggers {
     /* Note: If Add and Sub were type arguments of GenericTriggerGenerator, the latter
      *       could implement isForbiddenInTrigger already */
     def isForbiddenInTrigger(e: Exp) = (customIsForbiddenInTrigger orElse {
-      case _: ForbiddenInTrigger => true
+      case e if Expressions.isForbiddenInTrigger.isDefinedAt(e) => true
       case _ => false
     }: PartialFunction[Exp, Boolean])(e)
 

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -30,6 +30,7 @@ object Triggers {
     /* True iff the given node is a possible trigger */
     protected def isPossibleTrigger(e: Exp): Boolean = (customIsPossibleTrigger orElse {
       case _: PossibleTrigger => true
+      case ee: ExtensionExp => ee.extensionIsValidTrigger()
       case Old(_: PossibleTrigger) => true
       case LabelledOld(_: PossibleTrigger, _) => true
       case _ => false

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -39,7 +39,7 @@ object Triggers {
     /* Note: If Add and Sub were type arguments of GenericTriggerGenerator, the latter
      *       could implement isForbiddenInTrigger already */
     def isForbiddenInTrigger(e: Exp) = (customIsForbiddenInTrigger orElse {
-      case e if Expressions.isForbiddenInTrigger.isDefinedAt(e) => true
+      case e if Expressions.isForbiddenInTrigger(e) => true
       case _ => false
     }: PartialFunction[Exp, Boolean])(e)
 

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -207,7 +207,7 @@ case class AdtConstructorApp(name: String, args: Seq[Exp], typVarMap: Map[TypeVa
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = args.forall(a => !a.existsDefined(Expressions.isForbiddenInTrigger))
+  override def extensionIsValidTrigger(): Boolean = args.forall(a => !a.exists(Expressions.isForbiddenInTrigger))
 
   override def extensionIsForbiddenInTrigger(): Boolean = false
 }
@@ -258,7 +258,7 @@ case class AdtDestructorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, Type
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined(Expressions.isForbiddenInTrigger)
+  override def extensionIsValidTrigger(): Boolean = !rcv.exists(Expressions.isForbiddenInTrigger)
 
   override def extensionIsForbiddenInTrigger(): Boolean = false
 }

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -206,6 +206,8 @@ case class AdtConstructorApp(name: String, args: Seq[Exp], typVarMap: Map[TypeVa
       AdtConstructorApp(first, second, third)(this.pos, this.info, this.typ, this.adtName, this.errT).asInstanceOf[this.type]
     }
   }
+
+  override def validTrigger(p: Program): Boolean = args.forall(a => !a.existsDefined {case _: ForbiddenInTrigger => })
 }
 
 object AdtConstructorApp {
@@ -253,6 +255,8 @@ case class AdtDestructorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, Type
       AdtDestructorApp(first, second, third)(this.pos, this.info, this.typ, this.adtName, this.errT).asInstanceOf[this.type]
     }
   }
+
+  override def validTrigger(p: Program): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
 }
 
 object AdtDestructorApp {
@@ -306,6 +310,7 @@ case class AdtDiscriminatorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, T
     }
   }
 
+  override def validTrigger(p: Program): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
 }
 
 object AdtDiscriminatorApp {

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -207,7 +207,7 @@ case class AdtConstructorApp(name: String, args: Seq[Exp], typVarMap: Map[TypeVa
     }
   }
 
-  override def validTrigger(p: Program): Boolean = args.forall(a => !a.existsDefined {case _: ForbiddenInTrigger => })
+  override def extensionIsValidTrigger(): Boolean = args.forall(a => !a.existsDefined {case _: ForbiddenInTrigger => })
 }
 
 object AdtConstructorApp {
@@ -256,7 +256,7 @@ case class AdtDestructorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, Type
     }
   }
 
-  override def validTrigger(p: Program): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
+  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
 }
 
 object AdtDestructorApp {
@@ -310,7 +310,7 @@ case class AdtDiscriminatorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, T
     }
   }
 
-  override def validTrigger(p: Program): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
+  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
 }
 
 object AdtDiscriminatorApp {

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -314,9 +314,11 @@ case class AdtDiscriminatorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, T
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined(Expressions.isForbiddenInTrigger)
+  // Since a discriminator desugars to ADT_tag(rcv) == name_tag, which contains an equality,
+  // it cannot be used anywhere inside a trigger.
+  override def extensionIsValidTrigger(): Boolean = false
 
-  override def extensionIsForbiddenInTrigger(): Boolean = false
+  override def extensionIsForbiddenInTrigger(): Boolean = true
 }
 
 object AdtDiscriminatorApp {

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -9,7 +9,7 @@ package viper.silver.plugin.standard.adt
 import viper.silver.ast._
 import viper.silver.ast.pretty.FastPrettyPrinter.{ContOps, braces, brackets, char, defaultIndent, line, nest, nil, parens, show, showType, showVars, space, ssep, text}
 import viper.silver.ast.pretty.PrettyPrintPrimitives
-import viper.silver.ast.utility.Consistency
+import viper.silver.ast.utility.{Consistency, Expressions}
 import viper.silver.verifier.{ConsistencyError, Failure, VerificationResult}
 
 /**
@@ -207,7 +207,9 @@ case class AdtConstructorApp(name: String, args: Seq[Exp], typVarMap: Map[TypeVa
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = args.forall(a => !a.existsDefined {case _: ForbiddenInTrigger => })
+  override def extensionIsValidTrigger(): Boolean = args.forall(a => !a.existsDefined(Expressions.isForbiddenInTrigger))
+
+  override def extensionIsForbiddenInTrigger(): Boolean = false
 }
 
 object AdtConstructorApp {
@@ -256,7 +258,9 @@ case class AdtDestructorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, Type
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
+  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined(Expressions.isForbiddenInTrigger)
+
+  override def extensionIsForbiddenInTrigger(): Boolean = false
 }
 
 object AdtDestructorApp {
@@ -310,7 +314,9 @@ case class AdtDiscriminatorApp(name: String, rcv: Exp, typVarMap: Map[TypeVar, T
     }
   }
 
-  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined {case _: ForbiddenInTrigger => }
+  override def extensionIsValidTrigger(): Boolean = !rcv.existsDefined(Expressions.isForbiddenInTrigger)
+
+  override def extensionIsForbiddenInTrigger(): Boolean = false
 }
 
 object AdtDiscriminatorApp {

--- a/src/test/resources/all/issues/silver/0849.vpr
+++ b/src/test/resources/all/issues/silver/0849.vpr
@@ -1,0 +1,59 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+adt Term {
+  Const(n: Int)
+}
+
+domain theory {
+  function foo(t: Term): Bool
+
+  axiom ax1 { forall n: Int ::
+    {Const(n)}      // Type checker error
+    {foo(Const(n))} // OK
+    foo(Const(n))
+  }
+}
+
+method testConstr(s: Set[Int], j: Int) {
+  assume j in s
+  assume forall i: Int :: {Const(i)} i in s ==> i > 0
+  var t: Term := Const(j)
+  assert j > 0
+}
+
+method testConstrF(s: Set[Int], j: Int) {
+  assume j in s
+  assume forall i: Int :: {Const(i)} i in s ==> i > 0
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert j > 0
+}
+
+method testDestr(s: Set[Term], c: Term) {
+  assume c in s
+  assume forall i: Term :: {i.n} i in s ==> foo(i)
+  var t: Int := c.n
+  assert foo(c)
+}
+
+method testDestr2(s: Set[Term], c: Term) {
+  assume c in s
+  assume forall i: Term :: {i.n} i in s ==> foo(i)
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert foo(c)
+}
+
+method testDiscr(s: Set[Term], c: Term) {
+  assume c in s
+  assume forall i: Term :: {i.isConst} i in s ==> foo(i)
+  var t: Bool := c.isConst
+  assert foo(c)
+}
+
+method testDiscr2(s: Set[Term], c: Term) {
+  assume c in s
+  assume forall i: Term :: {i.isConst} i in s ==> foo(i)
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert foo(c)
+}

--- a/src/test/resources/all/issues/silver/0849.vpr
+++ b/src/test/resources/all/issues/silver/0849.vpr
@@ -46,14 +46,9 @@ method testDestr2(s: Set[Term], c: Term) {
 
 method testDiscr(s: Set[Term], c: Term) {
   assume c in s
-  assume forall i: Term :: {i.isConst} i in s ==> foo(i)
+  // i.isConst must not be picked as a trigger, otherwise the backends may crash
+  assume forall i: Term :: i.isConst ==> foo(i)
   var t: Bool := c.isConst
   assert foo(c)
 }
 
-method testDiscr2(s: Set[Term], c: Term) {
-  assume c in s
-  assume forall i: Term :: {i.isConst} i in s ==> foo(i)
-  //:: ExpectedOutput(assert.failed:assertion.false)
-  assert foo(c)
-}

--- a/src/test/resources/all/issues/silver/0849_2.vpr
+++ b/src/test/resources/all/issues/silver/0849_2.vpr
@@ -1,0 +1,25 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+adt Term {
+  Const(n: Int)
+}
+
+domain theory {
+  function foo(t: Term): Bool
+
+  axiom ax1 { forall n: Int ::
+    {Const(n)}      // Type checker error
+    {foo(Const(n))} // OK
+    foo(Const(n))
+  }
+}
+
+
+method testDiscr(s: Set[Term], c: Term) {
+  assume c in s
+  //:: ExpectedOutput(typechecker.error)
+  assume forall i: Term :: {i.isConst} i in s ==> foo(i)
+  assert foo(c)
+}


### PR DESCRIPTION
``ExtensionExp`` gets new abstract methods ``extensionIsValidTrigger`` and ``extensionIsForbiddenInTrigger`` (similar to ``extensionIsPure`` etc.), which return ``false`` and ``true`` by default, which can be used by extension expressions to decide whether they can be used as triggers or not. This replaces the previous behavior where our consistency checks would always reject extension expressions as triggers.

This fixes issue #849.