### PR TITLE
Disallow asserting expressions in axioms

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -568,6 +568,7 @@ sealed trait DomainAxiom extends DomainMember {
     (if(!Consistency.noResult(exp)) Seq(ConsistencyError("Axioms can never contain result variables.", exp.pos)) else Seq()) ++
     (if(!Consistency.noOld(exp)) Seq(ConsistencyError("Axioms can never contain old expressions.", exp.pos)) else Seq()) ++
     (if(!Consistency.noLocationAccesses(exp)) Seq(ConsistencyError("Axioms can never contain location accesses.", exp.pos)) else Seq()) ++
+    (if(!Consistency.noAsserting(exp)) Seq(ConsistencyError("Axioms can never contain asserting expressions.", exp.pos)) else Seq()) ++
     (if(!(exp isSubtype Bool)) Seq(ConsistencyError("Axioms must be of Bool type", exp.pos)) else Seq()) ++
     Consistency.checkPure(exp)
 

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -90,6 +90,9 @@ object Consistency {
   /** Returns true if the given node contains no location accesses. */
   def noLocationAccesses(n: Node) = !n.existsDefined { case _: LocationAccess => }
 
+  /** Returns true if the given node contains no asserting expressions. */
+  def noAsserting(n: Node) = !n.existsDefined { case _: Asserting => }
+
   /** Returns true if the given node contains no accessibility predicates (unfolding predicates is
     * allowed) and no magic wands (applying wands is allowed).
     */

--- a/src/test/resources/all/issues/silicon/0911.vpr
+++ b/src/test/resources/all/issues/silicon/0911.vpr
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+domain foo  {
+  function bar(): Bool
+
+  axiom {
+    //:: ExpectedOutput(consistency.error)
+    asserting (true) in true
+  }
+}
+
+function baz(): Int
+  requires bar()


### PR DESCRIPTION
Since axioms are not checked for well-definedness, there is no point in using ``asserting`` expressions in axioms; the assertion would never be checked. Thus, this PR introduces a consistency check that forbids asserting-expressions in axioms.

This indirectly fixes https://github.com/viperproject/silicon/issues/911.