### PR TITLE
Generalizing `AnnotationBasedTestSuite` to allow custom `AnnotatedTestInput`s

### DIFF
--- a/src/test/scala/AnnotationBasedTestSuite.scala
+++ b/src/test/scala/AnnotationBasedTestSuite.scala
@@ -29,7 +29,7 @@ abstract class AnnotationBasedTestSuite extends ResourceBasedTestSuite {
    */
   def systemsUnderTest: Seq[SystemUnderTest]
 
-  def buildTestInput(file: Path, prefix: String): DefaultAnnotatedTestInput =
+  def buildTestInput(file: Path, prefix: String): AnnotatedTestInput =
     DefaultAnnotatedTestInput(file, prefix)
 
   /** Registers a given test input for a given system under test. */
@@ -221,6 +221,8 @@ trait AnnotatedTestInput extends TestInput {
 
   /** Create a test input that is specific to the given project. */
   def makeForProject(projectInfo: ProjectInfo): AnnotatedTestInput
+
+  def copyWithFiles(files: Seq[Path]): AnnotatedTestInput
 }
 
 /** Test input that also includes test annotations. */
@@ -244,6 +246,8 @@ case class DefaultAnnotatedTestInput(
       tags = projectInfo.projectNames.map(Tag(_)) ++ tags.toList,
       annotations = annotations.filterByProject(projectInfo))
   }
+
+  def copyWithFiles(files: Seq[Path]): DefaultAnnotatedTestInput = copy(files = files)
 }
 
 object DefaultAnnotatedTestInput extends TestAnnotationParser {

--- a/src/test/scala/SingleFileSilSuite.scala
+++ b/src/test/scala/SingleFileSilSuite.scala
@@ -24,5 +24,5 @@ trait SingleFileSilSuite extends SilSuite {
   def frontend(verifier: Verifier, input: String): Frontend
 
   override def buildTestInput(file: Path, prefix: String) =
-    super.buildTestInput(file, prefix).copy(files = Seq(file))
+    super.buildTestInput(file, prefix).copyWithFiles(files = Seq(file))
 }


### PR DESCRIPTION
`buildTestInput` is currently quite restrictive as it only allows to return an instance of the `DefaultAnnotatedTestInput` case class. This PR relaxes this constraint such that instances of custom case classes extending `AnnotatedTestInput` can be returned.
This allows us in Gobra to extend a test input with additional arguments, namely a Gobra instance and an execution context, such that all data necessary to execute a testcase is contained in the corresponding test input. In particular, the execution of a testcase, thus, does not depend on fields of the corresponding test suite making parallel execution of testcases easier.
