### PR TITLE
Fix `PCall.forceSubstitution`

### DIFF
--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -965,11 +965,6 @@ case class PCall(idnref: PIdnRef[PCallable], callArgs: PDelimited.Comma[PSym.Par
       case _ => ots
     }
     super.forceSubstitution(ts)
-    typeSubstitutions.clear()
-    typeSubstitutions += ts
-    typ = typ.substitute(ts)
-    assert(typ.isGround)
-    args.foreach(_.forceSubstitution(ts))
   }
 }
 


### PR DESCRIPTION
If one calls `forceSubstitution` on a `n` nested `PCall` expression, we would get `2^n` calls to `forceSubstitution` since each `PCall` would call `forceSubstitution` on its children twice. See the attached Viper file for an example where this results in non-termination of typechecking (rename to `.vpr` after downloading).
[program-check.txt](https://github.com/user-attachments/files/19846303/program-check.txt)
