### PR TITLE
Allow adt constructors to have associated axiom

### DIFF
--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -268,6 +268,11 @@ sealed trait PIdnUseName[T <: PDeclarationInner] extends PIdnUse {
 /** Any `PNode` which should be ignored (as well as it's children) by the `NameAnalyser`. */
 trait PNameAnalyserOpaque extends PNode
 
+trait PNameAnalyserCustom extends PNode {
+  def nameDown(map: NameAnalyserCtxt): Unit
+  def nameUp(map: NameAnalyserCtxt): Unit
+}
+
 case class PIdnRef[T <: PDeclarationInner](name: String)(val pos: (Position, Position))(implicit val ctag: scala.reflect.ClassTag[T]) extends PIdnUseName[T] {
   override def rename(newName: String): PIdnUse = PIdnRef(newName)(pos)
   /** Changes the type of declaration which is referenced, preserves all previously added `decls` but discards `filters`. */
@@ -1691,7 +1696,11 @@ case class PDomainFunction(annotations: Seq[PAnnotation], unique: Option[PKw.Uni
   override def endLinebreak = false
 }
 
-case class PAxiom(annotations: Seq[PAnnotation], axiom: PKw.Axiom, idndef: Option[PIdnDef], exp: PBracedExp)(val pos: (Position, Position)) extends PDomainMember
+/** Declares that all children expressions must always be well-defined. This is
+ * enforced during type-checking. Used e.g. for axioms. */
+trait PAlwaysWellDefined
+
+case class PAxiom(annotations: Seq[PAnnotation], axiom: PKw.Axiom, idndef: Option[PIdnDef], exp: PBracedExp)(val pos: (Position, Position)) extends PDomainMember with PAlwaysWellDefined
 
 case class PDomainInterpretation(name: PRawString, c: PSym.Colon, lit: PStringLiteral)(val pos: (Position, Position)) extends PNode
 case class PDomainInterpretations(k: PReserved[PKeywordLang], m: PDelimited.Comma[PSym.Paren, PDomainInterpretation])(val pos: (Position, Position)) extends PNode {

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtASTExtension.scala
@@ -66,7 +66,7 @@ case class Adt(name: String, constructors: Seq[AdtConstructor], typVars: Seq[Typ
   * @param typ        the return type of the constructor
   * @param adtName    the name corresponding of the corresponding ADT
   */
-case class AdtConstructor(name: String, formalArgs: Seq[LocalVarDecl])
+case class AdtConstructor(name: String, formalArgs: Seq[LocalVarDecl], axiom: Option[Exp])
                          (val pos: Position, val info: Info, val typ: AdtType, val adtName: String, val errT: ErrorTrafo)
   extends ExtensionMember {
 
@@ -84,19 +84,20 @@ case class AdtConstructor(name: String, formalArgs: Seq[LocalVarDecl])
     if (!forceRewrite && this.children == children && pos.isEmpty)
       this
     else {
-      assert(children.length == 2, s"AdtConstructor : expected length 2 but got ${children.length}")
+      assert(children.length == 3, s"AdtConstructor : expected length 3 but got ${children.length}")
       val first = children.head.asInstanceOf[String]
       val second = children.tail.head.asInstanceOf[Seq[LocalVarDecl]]
-      AdtConstructor(first, second)(this.pos, this.info, this.typ, this.adtName, this.errT).asInstanceOf[this.type]
+      val third = children.tail.tail.head.asInstanceOf[Option[Exp]]
+      AdtConstructor(first, second, third)(this.pos, this.info, this.typ, this.adtName, this.errT).asInstanceOf[this.type]
     }
 
   }
 }
 
 object AdtConstructor {
-  def apply(adt: Adt, name: String, formalArgs: Seq[LocalVarDecl])
+  def apply(adt: Adt, name: String, formalArgs: Seq[LocalVarDecl], axiom: Option[Exp])
            (pos: Position = NoPosition, info: Info = NoInfo, errT: ErrorTrafo = NoTrafos): AdtConstructor = {
-    AdtConstructor(name, formalArgs)(pos, info, AdtType(adt, (adt.typVars zip adt.typVars).toMap), adt.name, errT)
+    AdtConstructor(name, formalArgs, axiom)(pos, info, AdtType(adt, (adt.typVars zip adt.typVars).toMap), adt.name, errT)
   }
 }
 

--- a/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/adt/AdtPlugin.scala
@@ -20,7 +20,7 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
                 config: viper.silver.frontend.SilFrontendConfig,
                 fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
 
-  import fp.{annotation, argList, idnTypeBinding, idndef, idnref, semiSeparated, typ, typeList, domainTypeVarDecl, ParserExtension, lineCol, _file}
+  import fp.{annotation, argList, idnTypeBinding, idndef, idnref, parenthesizedExp, semiSeparated, typ, typeList, domainTypeVarDecl, ParserExtension, lineCol, _file}
   import FastParserCompanion.{ExtendedParsing, LeadingWhitespace, PositionParsing, reservedKw, reservedSym, whitespace}
 
   /**
@@ -91,7 +91,9 @@ class AdtPlugin(@unused reporter: viper.silver.reporter.Reporter,
 
   def adtConstructorDecls[$: P]: P[PAdtSeq[PAdtConstructor]] = P(semiSeparated(adtConstructorDecl).braces.map(PAdtSeq.apply _)).pos
 
-  def adtConstructorDecl[$: P]: P[PAdtConstructor] = P((annotation.rep ~ idndef ~ argList(idnTypeBinding.map(PAdtFieldDecl(_)))) map (PAdtConstructor.apply _).tupled).pos
+  def adtConstructorDecl[$: P]: P[PAdtConstructor] = P((annotation.rep ~ idndef ~ argList(idnTypeBinding.map(PAdtFieldDecl(_))) ~ adtConstructorAxiom.?) map (PAdtConstructor.apply _).tupled).pos
+
+  def adtConstructorAxiom[$: P]: P[PAdtConstructorAxiom] = P((P(PKw.Axiom) ~ parenthesizedExp) map (PAdtConstructorAxiom.apply _).tupled).pos
 
   override def beforeResolve(input: PProgram): PProgram = {
     if (deactivated) {


### PR DESCRIPTION
The main advantage is that bounded types can be encoded as an `adt`. For example:
```boogie
adt u8 {
  to_u8(from_u8: Int)
    axiom (0 <= from_u8 < 256)
}
```

which is encoded as (the `0 <= from_u8 < 256 ==>` line and `axiom { forall t: u8 :: { from_u8(t) }  0 <= from_u8(t) < 256 }` axiom are new)

```boogie
domain u8  {
  function to_u8(from_u8: Int): u8 
  function from_u8(t: u8): Int 
  function u8_tag(t: u8): Int 
  
  axiom {
    forall from_u8: Int :: { to_u8(from_u8) }
      // new implication
      0 <= from_u8 < 256 ==>
        from_u8 == from_u8(to_u8(from_u8))
  }
  // new axiom
  axiom {
    forall t: u8 :: { from_u8(t) }  0 <= from_u8(t) < 256
  }
  
  axiom {
    forall from_u8: Int :: { to_u8(from_u8) } u8_tag(to_u8(from_u8)) == 0
  }
  axiom {
    forall t: u8 :: { u8_tag(t) } { from_u8(t) } false || t == to_u8(from_u8(t))
  }
}
```

Previously, one could try defining the regular adt and separately a `0 <= from_u8(t) < 256` axiom. However, this would be unsound as without the `==>` we would get e.g. `-1 == from_u8(to_u8(-1))` and `0 <= from_u8(to_u8(-1)) < 256`. This PR solves this, since the `==>` eliminates the injectivity fact in that case.

This feature is still dangerous in one specific case: it is unsound to write an unsatisfiable axiom (i.e. `axiom (false)` or equivalent). This would result in an `axiom { forall t: _ :: false }` in the encoded domain. The use of the `axiom` keyword should make this clear to users.