### PR TITLE
Avoiding Viper functions in hashsets and as keys in hashmaps

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -352,7 +352,7 @@ object Consistency {
       var msg = s"Function ${func.name} recurses via its precondition"
 
       if (cycleSet.nonEmpty) {
-        msg = s"$msg: the cycle contains the function(s) ${cycleSet.map(_.name).mkString(", ")}"
+        msg = s"$msg: the cycle contains the function(s) ${cycleSet.mkString(", ")}"
       }
 
       s :+= ConsistencyError(msg, func.pos)

--- a/src/main/scala/viper/silver/ast/utility/Consistency.scala
+++ b/src/main/scala/viper/silver/ast/utility/Consistency.scala
@@ -348,14 +348,14 @@ object Consistency {
 
   def checkNoFunctionRecursesViaPreconditions(program: Program): Seq[ConsistencyError] = {
     var s = Seq.empty[ConsistencyError]
-    Functions.findFunctionCyclesViaPreconditions(program) foreach { case (func, cycleSet) =>
-      var msg = s"Function ${func.name} recurses via its precondition"
+    Functions.findFunctionCyclesViaPreconditions(program) foreach { case (funcName, cycleSet) =>
+      var msg = s"Function ${funcName} recurses via its precondition"
 
       if (cycleSet.nonEmpty) {
         msg = s"$msg: the cycle contains the function(s) ${cycleSet.mkString(", ")}"
       }
 
-      s :+= ConsistencyError(msg, func.pos)
+      s :+= ConsistencyError(msg, program.findFunction(funcName).pos)
     }
     s
   }

--- a/src/main/scala/viper/silver/ast/utility/Functions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Functions.scala
@@ -187,7 +187,7 @@ object Functions {
     *         functions `fs`, then `f` (transitively) recurses via its precondition, and the
     *         formed cycles involves the set of functions `fs`.
     */
-  def findFunctionCyclesViaPreconditions(program: Program): Map[Function, Set[FuncName]] = {
+  def findFunctionCyclesViaPreconditions(program: Program): Map[FuncName, Set[FuncName]] = {
     findFunctionCyclesVia(program, func => func.pres, allSubexpressions)
   }
 
@@ -202,7 +202,7 @@ object Functions {
     *         formed cycles involves the set of functions `fs`.
     */
   def findFunctionCyclesVia(program: Program, via: Function => Seq[Exp], subs: Function => Seq[Exp] = allSubexpressions)
-      :Map[Function, Set[FuncName]] = {
+      :Map[FuncName, Set[FuncName]] = {
     def viaSubs(entryFunc: Function)(otherFunc: Function): Seq[Exp] =
       if (otherFunc == entryFunc)
         via(otherFunc)
@@ -227,7 +227,7 @@ object Functions {
     *         formed cycles involves the set of functions `fs`.
     */
   def findFunctionCyclesViaOptimized(program: Program, via: Function => Seq[Exp])
-  : Map[Function, Set[FuncName]] = {
+  : Map[FuncName, Set[FuncName]] = {
     val graph = getFunctionCallgraph(program, via)
     val res = program.functions.flatMap(func => {
       findCycles(graph, func)
@@ -235,12 +235,12 @@ object Functions {
     ListMap.from(res)
   }
 
-  private def findCycles(graph: DefaultDirectedGraph[FuncName, DefaultEdge], func: Function): Option[(Function, Set[FuncName])] = {
+  private def findCycles(graph: DefaultDirectedGraph[FuncName, DefaultEdge], func: Function): Option[(FuncName, Set[FuncName])] = {
     val cycleDetector = new CycleDetector(graph)
     val cycle = cycleDetector.findCyclesContainingVertex(func.name).asScala
     if (cycle.isEmpty)
       None
     else
-      Some(func -> cycle.toSet)
+      Some(func.name -> cycle.toSet)
   }
 }

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -251,7 +251,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
           val funcCycles = cycles.get(f)
           val problematicFuncApps = f.posts.flatMap(p => p.shallowCollect {
             case fa: FuncApp if fa.func(input) == f => fa
-            case fa: FuncApp if funcCycles.isDefined && funcCycles.get.contains(fa.func(input)) => fa
+            case fa: FuncApp if funcCycles.isDefined && funcCycles.get.contains(fa.funcname) => fa
           }).toSet
           for (fa <- problematicFuncApps) {
             val calledFunc = fa.func(input)

--- a/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/TerminationPlugin.scala
@@ -249,7 +249,7 @@ class TerminationPlugin(@unused reporter: viper.silver.reporter.Reporter,
           case dc: DecreasesClause => dc
         }.nonEmpty)
         if (!hasDecreasesClause) {
-          val funcCycles = cycles.get(f)
+          val funcCycles = cycles.get(f.name)
           val problematicFuncApps = f.posts.flatMap(p => p.shallowCollect {
             case fa: FuncApp if fa.func(input) == f => fa
             case fa: FuncApp if funcCycles.isDefined && funcCycles.get.contains(fa.funcname) => fa


### PR DESCRIPTION
I recently saw a Viper program where some consistency checks that need the call graph between functions took literal minutes, because various parts of the code calculating that graph use Viper AST functions as keys in maps. So lots of operations have to compute the hash code of those functions, which is apparently not cached in Scala's generated hash code implementation for case classes. And if the functions are sufficiently complex, this can apparently take forever.

So this PR just changes that code to compute maps from function names to sets of function names, instead of directly mapping functions to sets of functions.

This requires simple adaptations in Silicon and Carbon, which need to be merged first.