### PR TITLE
Do not add extra newline at end of file for position reasons

### DIFF
--- a/src/main/scala/viper/silver/ast/Position.scala
+++ b/src/main/scala/viper/silver/ast/Position.scala
@@ -108,8 +108,10 @@ class IdentifierPosition(val file: Path, val start: HasLineColumn, val end: Opti
 
 class LineCol(fp: FastParser) {
   def getPos(index: Int): (Int, Int) = {
-    // val Array(line, col) = ctx.input.prettyIndex(index).split(":").map(_.toInt)
     val line_offset = fp._line_offset
+    if (line_offset.isEmpty) {
+      return (1, 1);
+    }
     val result = java.util.Arrays.binarySearch(line_offset, index)
     if (result >= 0) {
       // Exact match

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -990,7 +990,7 @@ class FastParser {
     // Add an empty line at the end to make `computeFrom(s.length)` return
     // `(lines.length, 1)`, as the old implementation of `computeFrom` used to do.
     val lines = s.linesWithSeparators
-    _line_offset = (lines.map(_.length) ++ Seq(0)).toArray
+    _line_offset = lines.map(_.length).toArray
     var offset = 0
     for (i <- _line_offset.indices) {
       val line_length = _line_offset(i)

--- a/src/test/scala/AstPositionsTests.scala
+++ b/src/test/scala/AstPositionsTests.scala
@@ -63,7 +63,7 @@ class AstPositionsTests extends AnyFunSuite {
         |method bar(r: Ref)
         |  requires  0  >  r . foo
         |// Comment
-        |""".stripMargin
+        |function end(): Ref""".stripMargin
 
     val res: Program = generateViperAst(code).get
     // Check position of field
@@ -187,6 +187,18 @@ class AstPositionsTests extends AnyFunSuite {
       }
       case _ =>
         fail("methods must have start and end positions set")
+    }
+    // Check position of function
+    assert(res.functions.length === 1)
+    val fn: Function = res.functions(0)
+    fn.pos match {
+      case spos: AbstractSourcePosition =>
+        assert(spos.start.line === 15 && spos.end.get.line === 15)
+        // Here it is unclear if we want to include the `function ` part in the pos
+        assert(spos.start.column === 1 || spos.start.column === 10)
+        assert(spos.end.get.column === 20)
+      case _ =>
+        fail("functions must have start and end positions set")
     }
   }
 }


### PR DESCRIPTION
The following:
```
field f: Int
```

file would generate a `field` with position `((1,1), (2,1))`, even though the file only has a single line. The correct position should be `((1,1), (1, 13))`. This fixes that.