### PR TITLE
Add command line option to report partial results via StdIOReporter

### DIFF
--- a/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
@@ -152,6 +152,12 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
     noshort = true
   )
 
+  val reportPartialResults = opt[Boolean](name = "reportPartialResults",
+    descr = "Whether to report partial verification success and failure for individual members and branches.",
+    default = Some(false),
+    noshort = true
+  )
+
   validateOpt(file, ignoreFile) {
     case (_, Some(true)) => Right(())
     case (Some(filepath), _) => validateFileOpt(file.name, filepath)

--- a/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontEndConfig.scala
@@ -153,7 +153,7 @@ abstract class SilFrontendConfig(args: Seq[String], private var projectName: Str
   )
 
   val reportPartialResults = opt[Boolean](name = "reportPartialResults",
-    descr = "Whether to report partial verification success and failure for individual members and branches.",
+    descr = "Whether to report partial verification success and failure for individual members and branches via the StdIOReporter.",
     default = Some(false),
     noshort = true
   )

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -235,6 +235,7 @@ trait SilFrontend extends DefaultFrontend {
       resetPlugins()
       reporter match {
         case cf: ConfigurableReporter => cf.setConfig(Some(_config))
+        case _ =>
       }
     }
   }

--- a/src/main/scala/viper/silver/frontend/SilFrontend.scala
+++ b/src/main/scala/viper/silver/frontend/SilFrontend.scala
@@ -233,6 +233,9 @@ trait SilFrontend extends DefaultFrontend {
 
     if (_config != null) {
       resetPlugins()
+      reporter match {
+        case cf: ConfigurableReporter => cf.setConfig(Some(_config))
+      }
     }
   }
 


### PR DESCRIPTION
Viper (Silicon) has a system for reporting partial verification results (e.g. a member has been successfully verified or not), but currently, there is no way to access this information from the command line.

This PR adds a command line option ``--reportPartialResults`` that instructs the existing default StdIOReporter to also report these partial result messages.

Doing this required forwarding the overall configuration to the reporter.