### PR TITLE
Benchmarking messages

### DIFF
--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -330,3 +330,8 @@ case class VerificationTerminationMessage() extends Message {
   override val toString: String = "verification_termination_message"
   override val name: String = "verification_termination_message"
 }
+
+case class BenchmarkingMessage(category: String, payload: String) extends Message {
+  override val name: String = "benchmarking_message"
+  override val toString: String = s"Benchmarking message of type $category with payload $payload")
+}

--- a/src/main/scala/viper/silver/reporter/Message.scala
+++ b/src/main/scala/viper/silver/reporter/Message.scala
@@ -333,5 +333,5 @@ case class VerificationTerminationMessage() extends Message {
 
 case class BenchmarkingMessage(category: String, payload: String) extends Message {
   override val name: String = "benchmarking_message"
-  override val toString: String = s"Benchmarking message of type $category with payload $payload")
+  override val toString: String = s"Benchmarking message of type $category with payload $payload"
 }

--- a/src/main/scala/viper/silver/reporter/Reporter.scala
+++ b/src/main/scala/viper/silver/reporter/Reporter.scala
@@ -103,7 +103,7 @@ case class CSVReporter(name: String = "csv_reporter", path: String = "report.csv
         csv_file.write(s"BranchFailureMessage,${concerning.name},${cached}\n")
 
       case _: SimpleMessage | _: CopyrightReport | _: MissingDependencyReport | _: BackendSubProcessReport |
-           _: InternalWarningMessage | _: ConfigurationConfirmation=> // Irrelevant for reporting
+           _: InternalWarningMessage | _: ConfigurationConfirmation | _: BenchmarkingMessage => // Irrelevant for reporting
 
       case q: QuantifierInstantiationsMessage => csv_file.write(s"${q.toString}\n")
       case q: QuantifierChosenTriggersMessage => csv_file.write(s"${q.toString}\n")
@@ -221,6 +221,7 @@ case class StdIOReporter(name: String = "stdout_reporter", timeInfo: Boolean = t
       case _: QuantifierInstantiationsMessage => // too verbose, do not print
       case _: QuantifierChosenTriggersMessage => // too verbose, do not print
       case _: VerificationTerminationMessage =>
+      case _: BenchmarkingMessage =>
       case _ =>
         println( s"Cannot properly print message of unsupported type: $msg" )
     }


### PR DESCRIPTION
Having a general purpose benchmarking message in silver will allow us to more easily benchmark anything we would like in the frontends.

