### PR TITLE
Make Path accept resource URLs

### DIFF
--- a/src/main/scala/viper/silver/utility/Paths.scala
+++ b/src/main/scala/viper/silver/utility/Paths.scala
@@ -101,6 +101,28 @@ object Paths {
 
         fs.getPath(entryName)
 
+      case "resource" =>
+        val uriStr = uri.toString
+        assert(uriStr.startsWith("resource:/"), "Resource URL should start with \"resource:/\"")
+        val entryName = uriStr.substring(9)
+        val fileURI = URI.create("resource:/")
+
+        var fs: FileSystem = null
+
+        try {
+          fs = FileSystems.newFileSystem(fileURI, Map[String, Object]().asJava)
+          openFileSystems = fs +: openFileSystems
+        } catch {
+          case _: java.nio.file.FileSystemAlreadyExistsException =>
+            fs = FileSystems.getFileSystem(fileURI)
+            assert(fs.isOpen, "The reused file system is expected to still be open")
+        } finally {
+          assert(fs != null, s"Could not get hold of a file system for $fileURI (from $uriStr)")
+        }
+
+        fs.getPath(entryName)
+
+
       case other => sys.error(s"Resource $uri of scheme $other is not supported.")
     }
   }


### PR DESCRIPTION
This adds a handler for the `resource` scheme when creating a `Path` from a resource URL (essentially the same as the existing `jar` scheme). This is for compatibility with native images compiled by GraalVM.