### PR TITLE
Track dependencies to interpreted domain functions

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -961,6 +961,7 @@ trait Edges { this: Vertices =>
         case _ => Seq(Vertices.FunctionSpec(n.funcname))
       }
       case n: ast.DomainFuncApp => Seq(Vertices.DomainFunction(n.funcname))
+      case n: ast.BackendFuncApp => Seq(Vertices.DomainFunction(n.funcname))
       case n: ast.PredicateAccess => Seq(Vertices.PredicateSig(n.predicateName))
       // The call is fine because the result is used as the target of a dependency.
       case n: ast.Unfold => Seq(Vertices.unsafeGetPredicateBody(n.acc.loc.predicateName))


### PR DESCRIPTION
Those are currently missing, so the Chopper throws out domain functions with interpretations that are actually used and generates invalid programs.