### PR TITLE
Restricting recursiveCallsAndSurroundingUnfoldings to look for recursive calls only

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/Functions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Functions.scala
@@ -191,7 +191,9 @@ object Functions {
       case uf@Unfolding (_, body) =>
         recordCallsAndUnfoldings (body, ufs :+ uf) // note: acc is not recursively-processed - we may want to revisit this decision
       case fa@FuncApp (_, args) =>
-        result +:= (fa, ufs)
+        if (fa.funcname == f.name){
+          result +:= (fa, ufs)
+        }
         args.foreach ((n) => recordCallsAndUnfoldings (n, ufs) )
       }
     }

--- a/src/test/resources/all/issues/silver/0895.vpr
+++ b/src/test/resources/all/issues/silver/0895.vpr
@@ -1,0 +1,23 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+predicate OhHi() { true }
+
+function mark(): Bool
+{
+  true
+}
+
+function make_your_own_matching_loop(n: Int): Bool
+  requires OhHi()
+{
+    n <= 0 ? true : (unfolding OhHi() in mark()) && make_your_own_matching_loop(n - 1)
+}
+
+method main()
+{
+  fold OhHi()
+  var f: Bool := make_your_own_matching_loop(49)
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert f
+}


### PR DESCRIPTION
@JonasAlaif found that predicate triggers don't apply just to recursive calls but to any function calls, which is almost certainly not intended, contradicts the name of the function that looks for relevant calls, and can easily lead to matching loops (see #895). 

While there are other issues with the way the triggers are generated, this PR just fixes the most glaring issue and restricts the triggers to look for actual recursive calls only.