### PR TITLE
Add Chopper convenience method that just selects a set of names to create a single program

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -76,6 +76,20 @@ trait ChopperLike { this: ViperGraphs with Cut =>
   }
 
   /**
+    * chops `choppee` into multiple Viper programs. See [[chop]] for more details.
+    *
+    * @param choppee   Targeted program.
+    * @param selection Specifies the names of all members that should be verified.
+    * @return Chopped programs and metrics.
+    */
+  def chop(
+            choppee: ast.Program,
+            selection: Set[String],
+          ): Vector[ast.Program] = {
+    chopWithMetrics(choppee)(Some(m => selection.contains(m.name)))._1
+  }
+
+  /**
     * chops `choppee` into multiple Viper programs and returns metrics. See [[chop]] for more details.
     *
     * @param choppee   Targeted program.

--- a/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
+++ b/src/main/scala/viper/silver/ast/utility/chopper/Chopper.scala
@@ -76,17 +76,17 @@ trait ChopperLike { this: ViperGraphs with Cut =>
   }
 
   /**
-    * chops `choppee` into multiple Viper programs. See [[chop]] for more details.
+    * chops `choppee` into a single Viper program containing only the selected members. See [[chop]] for more details.
     *
     * @param choppee   Targeted program.
     * @param selection Specifies the names of all members that should be verified.
-    * @return Chopped programs and metrics.
+    * @return Chopped program, if anything was selected.
     */
   def chop(
             choppee: ast.Program,
             selection: Set[String],
-          ): Vector[ast.Program] = {
-    chopWithMetrics(choppee)(Some(m => selection.contains(m.name)))._1
+          ): Option[ast.Program] = {
+    chopWithMetrics(choppee)(Some(m => selection.contains(m.name)))._1.headOption
   }
 
   /**


### PR DESCRIPTION
This method just calls an existing one, but is much easier to use for frontends not written in Scala/Java, since it does not require a function object to be passed.