### PR TITLE
Add pure and access fragment functions for expressions

### DIFF
--- a/src/main/scala/viper/silver/ast/Program.scala
+++ b/src/main/scala/viper/silver/ast/Program.scala
@@ -9,6 +9,7 @@ package viper.silver.ast
 import viper.silver.ast.pretty.{Fixity, Infix, LeftAssociative, NonAssociative, Prefix, PrettyPrintPrimitives, RightAssociative}
 import utility.{Consistency, DomainInstances, Nodes, Types, Visitor}
 import viper.silver.ast.MagicWandStructure.MagicWandStructure
+import viper.silver.ast.utility.Expressions.{asAccessFragment, asPureFragment}
 import viper.silver.ast.utility.rewriter.StrategyBuilder
 import viper.silver.cfg.silver.{CfgGenerator, SilverCfg}
 import viper.silver.verifier.ConsistencyError
@@ -380,6 +381,8 @@ case class Predicate(name: String, formalArgs: Seq[LocalVarDecl], body: Option[E
 
   val scopedDecls: Seq[Declaration] = formalArgs
   def isAbstract = body.isEmpty
+  def getPureFragment: Option[Exp] = body.flatMap(asPureFragment)
+  def getAccessFragment: Option[Exp] = body.flatMap(asAccessFragment)
 
   override def isValid : Boolean = body match {
     case Some(e) if e.contains[PermExp] => false

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -140,7 +140,8 @@ object Expressions {
         (rec(thn), rec(els)) match {
           case (Some(thn2), Some(els2)) => Some(CondExp(cond, thn2, els2)(ite.pos, ite.info, ite.errT))
           case (Some(thn2), None) => Some(Implies(cond, thn2)(ite.pos, ite.info, ite.errT))
-          case (None, Some(els2)) => Some(Implies(cond, els2)(ite.pos, ite.info, ite.errT))
+          case (None, Some(els2)) =>
+            Some(Implies(Not(cond)(cond.pos, cond.info, cond.errT), els2)(ite.pos, ite.info, ite.errT))
           case (None, None) => None
         }
       case unf@Unfolding(acc, body) => rec(body).map(Unfolding(acc, _)(unf.pos, unf.info, unf.errT))

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -104,10 +104,17 @@ object Expressions {
     })
   }
 
+  /** Returns only the functional parts of an expression.
+    * Note: Result is likely not self-framing.
+    */
   def asPureFragment(e: Exp): Option[Exp] = {
     asFragment(e, pureFragment = true)
   }
 
+  /** Returns only the access/permission parts of an expression.
+    * Note: Result may not be well-defined on its own if functional properties are dropped,
+    * e.g. index bounds in QPs.
+    */
   def asAccessFragment(e: Exp): Option[Exp] = {
     asFragment(e, pureFragment = false)
   }

--- a/src/main/scala/viper/silver/ast/utility/Expressions.scala
+++ b/src/main/scala/viper/silver/ast/utility/Expressions.scala
@@ -104,6 +104,61 @@ object Expressions {
     })
   }
 
+  def asPureFragment(e: Exp): Option[Exp] = {
+    asFragment(e, pureFragment = true)
+  }
+
+  def asAccessFragment(e: Exp): Option[Exp] = {
+    asFragment(e, pureFragment = false)
+  }
+
+  private def asFragment(e: Exp, pureFragment: Boolean): Option[Exp] = {
+    def rec(e2: Exp): Option[Exp] = asFragment(e2, pureFragment)
+
+    e match {
+      case _: AccessPredicate => if (pureFragment) None else Some(e)
+      case ie@InhaleExhaleExp(in, ex) => for {
+        in2 <- rec(in)
+        ex2 <- rec(ex)
+      } yield InhaleExhaleExp(in2, ex2)(ie.pos, ie.info, ie.errT)
+      case imp@Implies(left, right) => rec(right).map(Implies(left, _)(imp.pos, imp.info, imp.errT))
+      case and@And(left, right) =>
+        (rec(left), rec(right)) match {
+          case (Some(left2), Some(right2)) => Some(And(left2, right2)(and.pos, and.info, and.errT))
+          case (Some(left2), None) => Some(left2)
+          case (None, Some(right2)) => Some(right2)
+          case (None, None) => None
+        }
+      case ite@CondExp(cond, thn, els) =>
+        (rec(thn), rec(els)) match {
+          case (Some(thn2), Some(els2)) => Some(CondExp(cond, thn2, els2)(ite.pos, ite.info, ite.errT))
+          case (Some(thn2), None) => Some(Implies(cond, thn2)(ite.pos, ite.info, ite.errT))
+          case (None, Some(els2)) => Some(Implies(cond, els2)(ite.pos, ite.info, ite.errT))
+          case (None, None) => None
+        }
+      case unf@Unfolding(acc, body) => rec(body).map(Unfolding(acc, _)(unf.pos, unf.info, unf.errT))
+      case app@Applying(wand, body) => rec(body).map(Applying(wand, _)(app.pos, app.info, app.errT))
+      case ass@Asserting(a, body) => rec(body).map(Asserting(a, _)(ass.pos, ass.info, ass.errT))
+      case let@Let(variable, exp, body) => rec(body).map(Let(variable, exp, _)(let.pos, let.info, let.errT))
+      case qa@Forall(_, _, exp) => rec(exp).map(exp2 => qa.copy(exp = exp2)(qa.pos, qa.info, qa.errT))
+      case qe@Exists(_, _, exp) => rec(exp).map(exp2 => qe.copy(exp = exp2)(qe.pos, qe.info, qe.errT))
+      case ext: ExtensionExp => if (ext.extensionIsPure == pureFragment) Some(ext) else None
+      case _: Literal
+           | _: AbstractLocalVar
+           | _: BinExp
+           | _: UnExp
+           | _: LocationAccess
+           | _: PermExp
+           | _: ForPerm
+           | _: FuncLikeApp
+           | _: SeqExp
+           | _: SetExp
+           | _: MultisetExp
+           | _: MapExp
+      => if (pureFragment) Some(e) else None
+    }
+  }
+
   def whenInhaling(e: Exp) = e.transform({
     case InhaleExhaleExp(in, _) => in
   }, Traverse.BottomUp)


### PR DESCRIPTION
Adds a function to split expressions into their pure/functional fragment and their access component. Includes convenience function to split predicate bodies in pure and access fragments.