### PR TITLE
Add synchronization during logger creation

### DIFF
--- a/src/main/scala/viper/silver/logger/ViperLogger.scala
+++ b/src/main/scala/viper/silver/logger/ViperLogger.scala
@@ -36,7 +36,7 @@ class ViperLogger(val name: String, val file: Option[String], val level: String)
   private def createLoggerFor(string: String, file: Option[String], str_level: String) = {
     var lc: LoggerContext = null
     var logger: Logger = null
-    // ME: Must synchronize to avoid getting ClassCastExceptions due when getting substitute loggers,
+    // ME: Must synchronize to avoid getting ClassCastExceptions when getting substitute loggers,
     // see Silicon issue #968
     ViperLogger.synchronized {
       lc = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]

--- a/src/main/scala/viper/silver/logger/ViperLogger.scala
+++ b/src/main/scala/viper/silver/logger/ViperLogger.scala
@@ -34,8 +34,14 @@ class ViperLogger(val name: String, val file: Option[String], val level: String)
 
   /** Borrowed from  */
   private def createLoggerFor(string: String, file: Option[String], str_level: String) = {
-    val lc = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    val logger = LoggerFactory.getLogger(string).asInstanceOf[Logger]
+    var lc: LoggerContext = null
+    var logger: Logger = null
+    // ME: Must synchronize to avoid getting ClassCastExceptions due when getting substitute loggers,
+    // see Silicon issue #968
+    ViperLogger.synchronized {
+      lc = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      logger = LoggerFactory.getLogger(string).asInstanceOf[Logger]
+    }
     file match {
       case Some(f_name) =>
         val fileAppender: FileAppender[ILoggingEvent] = new FileAppender[ILoggingEvent]


### PR DESCRIPTION
When using multiple instances of the ``FrontendAPI`` in parallel, this should avoid one thread asking for a logger while logger initialization triggered by another thread is still ongoing, which leads to a ``ClassCastException``, as shown in https://github.com/viperproject/silicon/issues/968. 