### PR TITLE
Properly handle InhaleExhale assertions inside QP desugaring code

### DIFF
--- a/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
+++ b/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
@@ -161,7 +161,19 @@ object QuantifiedPermissions {
     }
   }
 
-  def desugarSourceQuantifiedPermissionSyntax(source: Forall): Seq[Forall] = {
+  def desugarSourceQuantifiedPermissionSyntax(source: Forall): Seq[Exp] = {
+    val sourceIn = source.whenInhaling.asInstanceOf[Forall]
+    if (sourceIn == source) {
+      doDesugarSourceQuantifiedPermissionSyntax(source)
+    } else {
+      val sourceEx = source.whenExhaling.asInstanceOf[Forall]
+      val resIn = doDesugarSourceQuantifiedPermissionSyntax(sourceIn)
+      val resEx = doDesugarSourceQuantifiedPermissionSyntax(sourceEx)
+      resIn.map(InhaleExhaleExp(_, TrueLit()(source.pos, source.info))(source.pos, source.info)) ++
+        resEx.map(InhaleExhaleExp(TrueLit()(source.pos, source.info), _)(source.pos, source.info))
+    }
+  }
+  def doDesugarSourceQuantifiedPermissionSyntax(source: Forall): Seq[Forall] = {
 
 
     source match {
@@ -177,7 +189,7 @@ object QuantifiedPermissions {
             /* RHS is a conjunction; split into two foralls and recursively rewrite these */
 
             val foralls0 =
-              desugarSourceQuantifiedPermissionSyntax(
+              doDesugarSourceQuantifiedPermissionSyntax(
                 Forall(
                   vars,
                   triggers,
@@ -185,7 +197,7 @@ object QuantifiedPermissions {
                 )(source.pos, source.info))
 
             val foralls1 =
-              desugarSourceQuantifiedPermissionSyntax(
+              doDesugarSourceQuantifiedPermissionSyntax(
                 Forall(
                   vars,
                   triggers,
@@ -206,7 +218,7 @@ object QuantifiedPermissions {
                 Implies(newCond, e1)(rhs.pos, rhs.info) // TODO: this positional/info choice seems surprising. See also issue #249
               )(source.pos, source.info)
 
-            desugarSourceQuantifiedPermissionSyntax(newForall)
+            doDesugarSourceQuantifiedPermissionSyntax(newForall)
 
           case CondExp(b, e0, e1) =>
             /* RHS is a conditional assertion; pull its condition out and rewrite the resulting foralls */
@@ -215,14 +227,14 @@ object QuantifiedPermissions {
             val newCond1 = And(cond, Not(b)(b.pos,b.info))(cond.pos, MakeInfoPair(cond.info,b.info))
 
             val newForalls0 =
-              desugarSourceQuantifiedPermissionSyntax(Forall(
+              doDesugarSourceQuantifiedPermissionSyntax(Forall(
                 vars,
                 triggers,
                 Implies(newCond0, e0)(rhs.pos, rhs.info) // TODO: this positional/info choice seems surprising. See also issue #249
               )(source.pos, source.info))
 
             val newForalls1 =
-              desugarSourceQuantifiedPermissionSyntax(Forall(
+              doDesugarSourceQuantifiedPermissionSyntax(Forall(
                 vars,
                 triggers,
                 Implies(newCond1, e1)(rhs.pos, rhs.info) // TODO: this positional/info choice seems surprising. See also issue #249
@@ -245,12 +257,12 @@ object QuantifiedPermissions {
 
             val newCond = And(cond, nestedCond)(cond.pos, MakeInfoPair(cond.info,nestedCond.info))
 
-            desugarSourceQuantifiedPermissionSyntax(Forall(vars ++ nestedVars, combinedTriggers, Implies(newCond, nestedRhs)(rhs.pos, rhs.info, rhs.errT))(source.pos,MakeInfoPair(source.info, nested.info),MakeTrafoPair(source.errT,nested.errT)))
+            doDesugarSourceQuantifiedPermissionSyntax(Forall(vars ++ nestedVars, combinedTriggers, Implies(newCond, nestedRhs)(rhs.pos, rhs.info, rhs.errT))(source.pos,MakeInfoPair(source.info, nested.info),MakeTrafoPair(source.errT,nested.errT)))
 
           case lt@Let(v, e, bod) => {
             val forallWithoutLet = Forall(vars, triggers, bod)(source.pos, source.info)
             // desugar the let-body
-            val desugaredWithoutLet = desugarSourceQuantifiedPermissionSyntax(forallWithoutLet)
+            val desugaredWithoutLet = doDesugarSourceQuantifiedPermissionSyntax(forallWithoutLet)
             desugaredWithoutLet.map{
               case SourceQuantifiedPermissionAssertion(iqp, Implies(icond, irhs)) if (!irhs.isPure) =>
                 // Since the rhs cannot be a let-binding, we expand the let-expression in it.

--- a/src/test/resources/all/issues/silicon/0994.vpr
+++ b/src/test/resources/all/issues/silicon/0994.vpr
@@ -1,0 +1,10 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field int: Int
+
+method zero1(r: Ref)
+  requires (forall i0: Int ::
+      0 <= i0 && i0 < 1 ==>
+      [acc(r.int, write), acc(r.int, write)]
+  )


### PR DESCRIPTION
Fixes https://github.com/viperproject/silicon/issues/994. 
For quantifiers that do not contain any inhale-exhale-assertions, the desugaring is unchanged. 
For some quantifier ``Q`` whose inhaling-view is ``QI`` and whose exhaling-view is ``QE``, the new code transforms ``QI`` and ``QE`` separately, giving us some resulting quantifiers ``QI1, ..., QIn`` and ``QE1, ..., QEm``, and then wraps them back into inhale-exhale assertions, resulting in ``[QI1, true], ..., [QIn, true], [true, QE1], ..., [true, QEm]``. 