### PR TITLE
Fix compiler warnings and treat them as errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ ThisBuild / scalacOptions ++= Seq(
   "-feature",                         // Warn on features that requires explicit import
   "-Wunused",                         // Warn on unused imports
   "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
-  // "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
+  "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
 )
 
 // Enforce UTF-8, instead of relying on properly set locales
@@ -42,6 +42,12 @@ lazy val silver = (project in file("."))
     // Fork test to a different JVM than SBT's, avoiding SBT's classpath interfering with
     // classpath used by Scala's reflection.
     Test / fork := true,
+
+    // Scaladoc still reports a number of pre-existing warnings (mostly links that cannot be
+    // resolved), so `-Xfatal-warnings` is not applied to it; otherwise `doc`, and with it
+    // `publishLocal`, would fail.
+    Compile / doc / scalacOptions -= "-Xfatal-warnings",
+    Test / doc / scalacOptions -= "-Xfatal-warnings",
 
     // Compilation settings
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,             // Scala

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ ThisBuild / scalacOptions ++= Seq(
   "-feature",                         // Warn on features that requires explicit import
   "-Wunused",                         // Warn on unused imports
   "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
-  "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
 )
 
 // Enforce UTF-8, instead of relying on properly set locales
@@ -42,6 +41,13 @@ lazy val silver = (project in file("."))
     // Fork test to a different JVM than SBT's, avoiding SBT's classpath interfering with
     // classpath used by Scala's reflection.
     Test / fork := true,
+
+    // Treat warnings as errors to guarantee code quality in future changes. Note that this is
+    // deliberately scoped to the Silver project rather than added to the `ThisBuild / scalacOptions`
+    // above: this file is also loaded when a backend (e.g. Silicon or Carbon) includes Silver as a
+    // subproject, and settings in the `ThisBuild` scope would then apply to the backend's own
+    // sources as well, breaking its build on warnings that are unrelated to Silver.
+    scalacOptions += "-Xfatal-warnings",
 
     // Scaladoc still reports a number of pre-existing warnings (mostly links that cannot be
     // resolved), so `-Xfatal-warnings` is not applied to it; otherwise `doc`, and with it

--- a/src/main/scala/viper/silver/ast/Expression.scala
+++ b/src/main/scala/viper/silver/ast/Expression.scala
@@ -581,7 +581,7 @@ sealed trait QuantifiedExp extends Exp with Scope {
 }
 
 object QuantifiedExp {
-  def unapply(q: QuantifiedExp): Option[(Seq[LocalVarDecl], Exp)] = Some(q.variables, q.exp)
+  def unapply(q: QuantifiedExp): Some[(Seq[LocalVarDecl], Exp)] = Some((q.variables, q.exp))
 }
 
 /** Universal quantification. */

--- a/src/main/scala/viper/silver/ast/Statement.scala
+++ b/src/main/scala/viper/silver/ast/Statement.scala
@@ -57,6 +57,7 @@ object AbstractAssign {
   def apply(lhs: Lhs, rhs: Exp)(pos: Position = NoPosition, info: Info = NoInfo, errT: ErrorTrafo = NoTrafos) = lhs match {
     case l: LocalVar => LocalVarAssign(l, rhs)(pos, info, errT)
     case l: FieldAccess => FieldAssign(l, rhs)(pos, info, errT)
+    case l => sys.error(s"Cannot assign to left-hand side $l.")
   }
 
   def unapply(a: AbstractAssign) = Some((a.lhs, a.rhs))

--- a/src/main/scala/viper/silver/ast/utility/GenericAxiomRewriter.scala
+++ b/src/main/scala/viper/silver/ast/utility/GenericAxiomRewriter.scala
@@ -214,8 +214,8 @@ abstract class GenericAxiomRewriter[Type <: AnyRef,
     var rewrittenTriggerSets = triggerSets
     var rewrittenBody = Quantification_body(quantification)
 
-    for ((qvar, entries) <- solved;
-         (invalidTerm, substVar, solution) <- entries) {
+    for ((_, entries) <- solved;
+         (invalidTerm, substVar, _) <- entries) {
 
       /* Replace each occurrence of invalidTerm with substVar */
       rewrittenTriggerSets =

--- a/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
+++ b/src/main/scala/viper/silver/ast/utility/QuantifiedPermissions.scala
@@ -263,7 +263,7 @@ object QuantifiedPermissions {
             val forallWithoutLet = Forall(vars, triggers, bod)(source.pos, source.info)
             // desugar the let-body
             val desugaredWithoutLet = doDesugarSourceQuantifiedPermissionSyntax(forallWithoutLet)
-            desugaredWithoutLet.map{
+            desugaredWithoutLet.map{ (desugared: Forall) => (desugared: @unchecked) match {
               case SourceQuantifiedPermissionAssertion(iqp, Implies(icond, irhs)) if (!irhs.isPure) =>
                 // Since the rhs cannot be a let-binding, we expand the let-expression in it.
                 // However, we still use a let in the condition; this preserves well-definedness if v isn't used anywhere
@@ -271,7 +271,7 @@ object QuantifiedPermissions {
               case iforall@Forall(ivars, itriggers, Implies(icond, ibod)) =>
                 // For all pure parts of the quantifier, we just re-wrap the body into a let.
                 Forall(ivars, itriggers, Implies(cond, Let(v, e, Implies(icond, ibod)(lt.pos, lt.info))(lt.pos, lt.info, lt.errT))(lt.pos, lt.info, lt.errT))(iforall.pos, iforall.info)
-            }
+            }}
           }
           case _ =>
             /* RHS does not need to be desugared (any further) */

--- a/src/main/scala/viper/silver/ast/utility/Simplifier.scala
+++ b/src/main/scala/viper/silver/ast/utility/Simplifier.scala
@@ -11,6 +11,8 @@ import viper.silver.ast._
 import viper.silver.ast.utility.rewriter._
 import viper.silver.utility.Common.Rational
 
+import scala.annotation.nowarn
+
 /**
  * An implementation for simplifications on the Viper AST.
  */
@@ -28,6 +30,9 @@ object Simplifier {
       assumeWelldefinedness || Expressions.isKnownWellDefined(e, None)
     }
 
+    /* The match below is deliberately partial (it is a `PartialFunction`), but it is large enough
+     * that the compiler runs out of budget while checking it for unreachable cases. */
+    @nowarn("msg=Cannot check match for unreachability")
     val simplifySingle: PartialFunction[Node, Node] = {
       // expression simplifications
       case root: Exp if root.simplified.isDefined =>

--- a/src/main/scala/viper/silver/ast/utility/Triggers.scala
+++ b/src/main/scala/viper/silver/ast/utility/Triggers.scala
@@ -53,7 +53,7 @@ object Triggers {
 
     protected def getArgs(e: Exp): Seq[Exp] = e match {
       case pt: PossibleTrigger => pt.getArgs
-      case fa: FieldAccess => fa.getArgs
+      case fa: FieldAccess => fa.getArgs()
       case Old(pt: PossibleTrigger) => pt.getArgs
       case LabelledOld(pt: PossibleTrigger, _) => pt.getArgs
       case _ => sys.error(s"Unexpected expression $e")

--- a/src/main/scala/viper/silver/ast/utility/rewriter/RegexStrategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/RegexStrategy.scala
@@ -6,6 +6,7 @@
 
 package viper.silver.ast.utility.rewriter
 
+import scala.annotation.unused
 import scala.reflect.runtime.{universe => reflection}
 
 /**
@@ -128,7 +129,7 @@ class RegexStrategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTa
 
     }
     // Get the tuple that matches parameter node
-    def get(node: N, ancList: Seq[N]): Option[CTXT] = {
+    def get(node: N, @unused ancList: Seq[N]): Option[CTXT] = {
       // Get all matching nodes together with their index (only way to delete them later)
       val candidates = map.zipWithIndex.filter( _._1._1 eq node )
 

--- a/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/Strategy.scala
@@ -237,7 +237,10 @@ class AddArtificialContext[N <: Rewritable](p: PartialFunction[N, N]) extends Pa
 class SlimStrategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag](p: PartialFunction[N, N]) extends Strategy[N, SimpleContext[N]](new AddArtificialContext(p))
 
 // Generic Strategy class. Includes all the required functionality
-class Strategy[N <: Rewritable : reflection.TypeTag : scala.reflect.ClassTag, C <: Context[N]](p: PartialFunction[(N, C), (N, C)]) extends StrategyInterface[N] {
+// The `TypeTag` and `ClassTag` evidence is not used here, but is kept because subclasses and the
+// `StrategyBuilder` factory methods rely on it being available.
+class Strategy[N <: Rewritable, C <: Context[N]](p: PartialFunction[(N, C), (N, C)])
+              (implicit @unused typeTag: reflection.TypeTag[N], @unused classTag: scala.reflect.ClassTag[N]) extends StrategyInterface[N] {
 
   // Defines the traversion mode
   protected var traversionMode: Traverse = Traverse.TopDown
@@ -796,7 +799,7 @@ class ContextC[N <: Rewritable, CUSTOM](aList: Seq[N], val c: CUSTOM, transforme
   }
 
   // Perform the custom update part of the update
-  def updateCustom(n: N): ContextC[N, CUSTOM] = {
+  def updateCustom(@unused n: N): ContextC[N, CUSTOM] = {
     new ContextC[N, CUSTOM](ancestorList, c, transformer)
   }
 
@@ -820,7 +823,7 @@ class ContextC[N <: Rewritable, CUSTOM](aList: Seq[N], val c: CUSTOM, transforme
 class ContextCustom[N <: Rewritable, CUSTOM](val c: CUSTOM, override protected val transformer: StrategyInterface[N]) extends SimpleContext[N](transformer) {
 
   // Perform the custom update part of the update
-  def updateCustom(n: N): ContextCustom[N, CUSTOM] = {
+  def updateCustom(@unused n: N): ContextCustom[N, CUSTOM] = {
     new ContextCustom[N, CUSTOM](c, transformer)
   }
 

--- a/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
+++ b/src/main/scala/viper/silver/ast/utility/rewriter/TRegex.scala
@@ -94,7 +94,7 @@ trait Match {
 class NMatch[N <: Rewritable : TypeTag](val pred: N => Boolean, val rewrite: Boolean) extends Match {
 
   // Checks if node n (of type T) is a valid subtype of generic parameter N
-  protected def matches[T: TypeTag](n: T): Boolean = {
+  protected def matches[T](n: T)(implicit @unused typeTag: TypeTag[T]): Boolean = {
     // TODO: This code works but im not really familiar with reflection. Is there a better solution?
     val mirror = runtimeMirror(n.getClass.getClassLoader) // obtain runtime mirror
     val sym = mirror.staticClass(n.getClass.getName) // obtain class symbol for `n`

--- a/src/main/scala/viper/silver/cfg/Block.scala
+++ b/src/main/scala/viper/silver/cfg/Block.scala
@@ -86,7 +86,7 @@ object PreconditionBlock {
   def apply[S, E](pres: Seq[E]): PreconditionBlock[S, E] =
     new PreconditionBlock(Block.nextId(), pres)
 
-  def unapply[S, E](block: PreconditionBlock[S, E]): Option[Seq[E]] =
+  def unapply[S, E](block: PreconditionBlock[S, E]): Some[Seq[E]] =
     Some(block.pres)
 }
 
@@ -109,7 +109,7 @@ object PostconditionBlock {
   def apply[S, E](posts: Seq[E]): PostconditionBlock[S, E] =
     new PostconditionBlock(Block.nextId(), posts)
 
-  def unapply[S, E](block: PostconditionBlock[S, E]): Option[Seq[E]] =
+  def unapply[S, E](block: PostconditionBlock[S, E]): Some[Seq[E]] =
     Some(block.posts)
 }
 

--- a/src/main/scala/viper/silver/cfg/silver/SilverCfg.scala
+++ b/src/main/scala/viper/silver/cfg/silver/SilverCfg.scala
@@ -104,9 +104,9 @@ class SilverCfg(val blocks: Seq[SilverBlock], val edges: Seq[SilverEdge], val en
   : (Option[SilverBlock], mutable.Map[SilverBlock, SilverBlock]) = {
 
     var queue = mutable.Queue.from(queueInit)
-    var visited: mutable.Set[SilverBlock] = mutable.Set.from(visitedInit)
+    val visited: mutable.Set[SilverBlock] = mutable.Set.from(visitedInit)
     val map = mutable.Map[SilverBlock, SilverBlock]()
-    var loopHeads: mutable.Set[SilverBlock] = mutable.Set.from(loopHeadsSeen)
+    val loopHeads: mutable.Set[SilverBlock] = mutable.Set.from(loopHeadsSeen)
 
     // BFS traversal of CFG.
     while (queue.nonEmpty) {

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -6,7 +6,6 @@
 
 package viper.silver.parser
 
-import java.net.URL
 import java.nio.file.{Path, Paths}
 import viper.silver.ast.{FilePosition, LineCol, NoPosition, SourcePosition}
 import viper.silver.ast.utility.{DiskLoader, FileLoader}
@@ -43,7 +42,7 @@ object FastParserCompanion {
   def space[$: P] = " " | "\t"
   def newline[$: P] = StringIn("\r\n") | "\n" | "\r"
 
-  implicit val whitespace = {
+  implicit val whitespace: ParsingRun[_] => P[Unit] = {
     import NoWhitespace._
     implicit ctx: ParsingRun[_] =>
       NoTrace((blockComment | lineComment | space | newline).rep)
@@ -55,9 +54,9 @@ object FastParserCompanion {
   type Pos = (FilePosition, FilePosition)
   import scala.language.implicitConversions
   implicit def LeadingWhitespaceStr[$: P](p: String): LeadingWhitespace[Unit] = new LeadingWhitespace(() => P(p))
-  implicit def LeadingWhitespace[T](p: => P[T]) = new LeadingWhitespace(() => p)
-  implicit def PositionParsing[T](p: => P[Pos => T]) = new PositionParsing(() => p)
-  implicit def ExtendedParsing[T](p: => P[T]) = new ExtendedParsing(() => p)
+  implicit def LeadingWhitespace[T](p: => P[T]): LeadingWhitespace[T] = new LeadingWhitespace(() => p)
+  implicit def PositionParsing[T](p: => P[Pos => T]): PositionParsing[T] = new PositionParsing(() => p)
+  implicit def ExtendedParsing[T](p: => P[T]): ExtendedParsing[T] = new ExtendedParsing(() => p)
   implicit def reservedKw[$: P, T <: PKeyword](r: T)(implicit lineCol: LineCol, _file: Path): P[PReserved[T]] = P(P(r.token).map { _ => PReserved(r)(_) } ~~ !identContinues)./.pos
   implicit def reservedSym[$: P, T <: PSymbol](r: T)(implicit lineCol: LineCol, _file: Path): P[PReserved[T]] = P(r.token./ map { _ => PReserved(r)(_) }).pos
 
@@ -294,11 +293,8 @@ class FastParser {
      */
     val relativeImportPath = Paths.get(standard_import_directory, path.toString)
 
-    /* Creates a corresponding relative URL, e.g. "file://import/my/stdlib.vpr" */
-    val relativeImportUrl = new URL(new URL("file:"), relativeImportPath.toString)
-
-    /* Extract the path component only, e.g. "import/my/stdlib.vpr" */
-    val relativeImportStr = relativeImportUrl.getPath
+    /* Use the path as the resource name, e.g. "import/my/stdlib.vpr" */
+    val relativeImportStr = relativeImportPath.toString
 
     // nested try-catch block because source.close() in finally could also cause a NullPointerException
     val buffer =
@@ -354,7 +350,7 @@ class FastParser {
   import FastParserCompanion.{ExtendedParsing, identContinues, identStarts, LeadingWhitespace, Pos, PositionParsing, reservedKw, reservedSym, blockComment, lineComment, newline, space}
 
 
-  implicit val whitespace = {
+  implicit val whitespace: ParsingRun[_] => P[Unit] = {
     import NoWhitespace._
     implicit ctx: ParsingRun[_] =>
       NoTrace((blockComment | lineComment | space | newline).rep)
@@ -1003,7 +999,7 @@ class FastParser {
     // Assume entire file is correct and try parsing it quickly
     fastparse.parse(s, entireProgram(_)) match {
       case Parsed.Success(value, _) => {
-        value.offsets = _line_offset;
+        value.offsets = _line_offset.toIndexedSeq;
         value.rawProgram = s;
         return value;
       }

--- a/src/main/scala/viper/silver/parser/MacroExpander.scala
+++ b/src/main/scala/viper/silver/parser/MacroExpander.scala
@@ -539,7 +539,7 @@ object MacroExpander {
           val replacement = ctx.c.paramToArgMap(lName.name).deepCopyAll
           val replaced = replacement match {
             case r: PIdnUseExp => PIdnDef(r.name)(r.pos)
-            case r =>
+            case _ =>
               throw MacroException(s"macro expansion cannot substitute expression `${replacement.pretty}` at ${replacement.pos._1} in non-expression position at ${lName.pos._1}.", replacement.pos)
           }
           (PLabel(lbl, replaced, invs)(label.pos), ctx.updateContext(ctx.c.copy(paramToArgMap = ctx.c.paramToArgMap.empty)))

--- a/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
+++ b/src/main/scala/viper/silver/plugin/ParserPluginTemplate.scala
@@ -6,7 +6,7 @@
 
 package viper.silver.plugin
 
-import viper.silver.parser.{NameAnalyser, PAnnotationsPosition, PExp, PExtender, PKeyword, PKw, PMember, PReserved, PSpecification, PStmt, PTypeSubstitution, RNode, ReformatterContext, Translator, TypeChecker}
+import viper.silver.parser.{NameAnalyser, PAnnotationsPosition, PExp, PExtender, PKeyword, PKw, PMember, PReserved, PSpecification, PStmt, PTypeSubstitution, Translator, TypeChecker}
 import viper.silver.ast.pretty.PrettyPrintPrimitives
 import viper.silver.ast.{Declaration, ErrorTrafo, Exp, ExtensionExp, ExtensionMember, ExtensionStmt, Info, Member, NoPosition, Node, Position, Stmt, Type}
 import viper.silver.verifier.VerificationResult

--- a/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
+++ b/src/main/scala/viper/silver/plugin/standard/termination/transformation/MethodCheck.scala
@@ -18,6 +18,8 @@ import viper.silver.verifier.errors.AssertFailed
  */
 trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicates with ErrorReporter {
 
+  import MethodCheck.Transformed
+
   private def getMethodDecreasesSpecification(method: String): DecreasesSpecification = {
     program.findMethodOptionally(method) match {
       case Some(f) => DecreasesSpecification.fromNode(f)
@@ -238,16 +240,6 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
       }
   }
 
-  /**
-   * Mark already traversed and transformed nodes.
-   * Used for while loops because a while node is potentially traversed twice.
-   */
-  private final case class Transformed() extends Info {
-    override val comment: Seq[String] = Nil
-
-    override val isCached: Boolean = false
-  }
-
   private var whileCounter: Int = 1
 
   private case class MContext(override val method: Method) extends MethodContext {
@@ -284,5 +276,21 @@ trait MethodCheck extends ProgramManager with DecreasesCheck with NestedPredicat
     })
 
     graph
+  }
+}
+
+object MethodCheck {
+
+  /**
+   * Mark already traversed and transformed nodes.
+   * Used for while loops because a while node is potentially traversed twice.
+   *
+   * Declared in the companion object (instead of in the trait itself) such that the class does not
+   * have an outer reference, which cannot be checked when pattern matching on it.
+   */
+  private final case class Transformed() extends Info {
+    override val comment: Seq[String] = Nil
+
+    override val isCached: Boolean = false
   }
 }

--- a/src/test/scala/CounterexampleVariablesTests.scala
+++ b/src/test/scala/CounterexampleVariablesTests.scala
@@ -12,6 +12,7 @@ import viper.silver.parser.{FastParser, PAccPred, PBinExp, PBoolLit, PExp, PIdnU
 import viper.silver.verifier.{ConstantEntry, FailureContext, Model, ModelEntry, VerificationError}
 
 import java.nio.file.Path
+import scala.annotation.unused
 
 trait CounterexampleVariablesTests extends SilSuite {
   override val testDirectories: Seq[String] = Seq("counterexample_variables")
@@ -60,8 +61,8 @@ trait CounterexampleVariablesTests extends SilSuite {
         // now parsing is actually possible:
         fastparse.parse(expectedCounterexampleString, cParser.expectedCounterexample(_)) match {
           case Parsed.Success(expectedCounterexample, _) => Some(createExpectedValuesCounterexampleAnnotation(id, file, lineNr, expectedCounterexample))
-          case Parsed.Failure(_, _, extra) =>
-            println(s"Parsing expected counterexample failed in file $file: ${extra.trace().longAggregateMsg}")
+          case failure: Parsed.Failure =>
+            println(s"Parsing expected counterexample failed in file $file: ${failure.extra.trace().longAggregateMsg}")
             None
         }
       }
@@ -78,7 +79,7 @@ trait CounterexampleVariablesTests extends SilSuite {
   }
 }
 
-abstract class ExpectedValuesCounterexampleAnnotation(id: OutputAnnotationId, file: Path, forLineNr: Int, expectedCounterexample: ExpectedCounterexample) extends CustomAnnotation {
+abstract class ExpectedValuesCounterexampleAnnotation(id: OutputAnnotationId, file: Path, forLineNr: Int, @unused expectedCounterexample: ExpectedCounterexample) extends CustomAnnotation {
   override def matches(actual: AbstractOutput): Boolean =
     id.matches(actual.fullId) && actual.isSameLine(file, forLineNr) && containsModel(actual)
 
@@ -104,8 +105,9 @@ object CounterexampleComparison {
   }
 
   def containsEquality(lhs: PExp, rhs: PExp, model: Model): Boolean =
-    resolve(Vector(lhs, rhs), model).exists { case Vector(resolvedLhs, resolvedRhs) =>
-      areEqualEntries(resolvedLhs, resolvedRhs)
+    resolve(Vector(lhs, rhs), model).exists {
+      case Vector(resolvedLhs, resolvedRhs) => areEqualEntries(resolvedLhs, resolvedRhs)
+      case _ => false
     }
 
   /** resolves `expr` to a model entry in the given model. In case it's a field access, the corresponding permissions are returned as well */
@@ -123,6 +125,7 @@ object CounterexampleComparison {
 
   def areEqualEntries(entry1: ModelEntry, entry2: ModelEntry): Boolean = (entry1, entry2) match {
     case (ConstantEntry(value1), ConstantEntry(value2)) => value1 == value2
+    case _ => false
   }
 }
 
@@ -134,7 +137,7 @@ object CounterexampleComparison {
 class CounterexampleParser(fp: FastParser) {
   import fp.{accessPred, eqExp}
 
-  def expectedCounterexample[_: P]: P[ExpectedCounterexample] =
+  def expectedCounterexample[$: P]: P[ExpectedCounterexample] =
     (Start ~ "(" ~ (accessPred | eqExp).rep(0, ",") ~ ")" ~ End)
       .map(ExpectedCounterexample)
 }

--- a/src/test/scala/ReformatterTests.scala
+++ b/src/test/scala/ReformatterTests.scala
@@ -17,6 +17,7 @@ class ReformatterTests extends AnyFunSuite {
     def parse(content: String): PProgram = {
       doParsing(content) match {
         case Succ(r) => r
+        case Fail(errors) => fail(s"parsing failed with the following errors: ${errors.mkString(", ")}")
       }
     }
 

--- a/src/test/scala/UtilityTests.scala
+++ b/src/test/scala/UtilityTests.scala
@@ -7,7 +7,8 @@
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import viper.silver.ast._
-import viper.silver.ast.utility.ImpureAssumeRewriter
+
+import scala.annotation.unused
 
 
 class UtilityTests extends AnyFunSuite with Matchers {
@@ -22,7 +23,7 @@ class UtilityTests extends AnyFunSuite with Matchers {
       ), Seq())(NoPosition, NoInfo, NoTrafos))
       )(NoPosition)
 
-    val testProgram : Program = Program(Seq(), Seq(Field("f",Int)(NoPosition)), Seq(), Seq(), Seq(testMethod), Seq())(NoPosition)
+    @unused val testProgram : Program = Program(Seq(), Seq(Field("f",Int)(NoPosition)), Seq(), Seq(), Seq(testMethod), Seq())(NoPosition)
 
     // val rewritten = AssumeRewriter.rewrite(assumeBody,testProgram)
 


### PR DESCRIPTION
Please review the unused members carefully, as it may point at implementation errors. I didn't drop dead code here, but I am happy to do it too.

Regarding unused parameters, it would be good to drop them, as clients may be performing heavy computations to compute these parameters without realizing they are not ufesul.