### PR TITLE
Adapt test annotations for Carbon QP exhaleExt

### DIFF
--- a/src/test/resources/all/issues/carbon/0203.vpr
+++ b/src/test/resources/all/issues/carbon/0203.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/203/)
 field val: Int
 
 method test()

--- a/src/test/resources/all/issues/carbon/0589.vpr
+++ b/src/test/resources/all/issues/carbon/0589.vpr
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+field next: Ref
+
+method test(x: Ref, z: Ref)
+    requires acc(z.f)
+{ package acc(x.next) && x.next == z --* forall y: Ref :: y == x.next ==> acc(y.f) }

--- a/src/test/resources/all/issues/silicon/0310b.vpr
+++ b/src/test/resources/all/issues/silicon/0310b.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/216/)
 
 field next: Ref;
 

--- a/src/test/resources/all/issues/silicon/0796.vpr
+++ b/src/test/resources/all/issues/silicon/0796.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/428/)
 
 field f: Int
 

--- a/src/test/resources/wands/new_syntax/QPFields.vpr
+++ b/src/test/resources/wands/new_syntax/QPFields.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/216/)
 field f: Int
 
 method test0(x: Ref)

--- a/src/test/resources/wands/new_syntax/QPPredicates.vpr
+++ b/src/test/resources/wands/new_syntax/QPPredicates.vpr
@@ -1,7 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/carbon/issue/216/)
 field f: Int
 
 predicate Cell(x: Ref) {


### PR DESCRIPTION
Enabling previously disabled tests that use exhaleExt for QPs in Carbon. Also adding a test specific to that implementation.